### PR TITLE
ci: remove redundant eas setup step

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -45,12 +45,6 @@ jobs:
           distribution: "zulu"
           java-version: "17"
 
-      - name: Setup Expo and EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
       - name: Build with EAS
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}


### PR DESCRIPTION
Eliminate redundant setup step for Expo and EAS in the CI configuration to streamline the workflow.