### PR TITLE
chore(data): add new thi semester dates

### DIFF
--- a/src/data/calendar.json
+++ b/src/data/calendar.json
@@ -10,164 +10,6 @@
 	},
 	{
 		"name": {
-			"de": "Rückmeldung zum Wintersemester 2024/2025",
-			"en": "Re-registration for winter semester 2024/2025"
-		},
-		"begin": "2024-07-02",
-		"end": "2024-08-07"
-	},
-	{
-		"name": {
-			"de": "Erweiterter Prüfungszeitraum",
-			"en": "Additional exam period"
-		},
-		"begin": "2024-07-04",
-		"end": "2024-07-10"
-	},
-	{
-		"name": {
-			"de": "Ende der Vorlesungszeit",
-			"en": "End of lecture period"
-		},
-		"begin": "2024-07-10"
-	},
-	{
-		"name": {
-			"de": "Prüfungszeitraum",
-			"en": "Exam period"
-		},
-		"begin": "2024-07-11",
-		"end": "2024-07-23"
-	},
-	{
-		"name": {
-			"de": "Notenmeldung",
-			"en": "Recording grades"
-		},
-		"begin": "2024-07-26T9:00",
-		"hasHours": true
-	},
-
-	{
-		"name": {
-			"de": "Notenbekanntgabe",
-			"en": "Announcement of grades"
-		},
-		"begin": "2024-07-31T13:00",
-		"hasHours": true
-	},
-	{
-		"name": {
-			"de": "Semesterferien",
-			"en": "Semester break"
-		},
-		"begin": "2024-08-01",
-		"end": "2024-09-30"
-	},
-	{
-		"name": {
-			"de": "Vorlesungsbeginn und Semesterstart",
-			"en": "Start of lectures and semester"
-		},
-		"begin": "2024-10-01"
-	},
-	{
-		"name": {
-			"de": "Vorlesungsfrei",
-			"en": "No lectures"
-		},
-		"begin": "2024-10-31",
-		"end": "2024-11-01"
-	},
-	{
-		"name": {
-			"de": "Prüfungsanmeldung",
-			"en": "Registration for exams"
-		},
-		"begin": "2024-11-08",
-		"end": "2024-11-17"
-	},
-	{
-		"name": {
-			"de": "Prüfungsabmeldung",
-			"en": "Deregistration for exams"
-		},
-		"begin": "2024-11-08",
-		"end": "2025-01-10"
-	},
-	{
-		"name": {
-			"de": "Vorlesungsfrei (Weihnachten)",
-			"en": "No lectures (Christmas)"
-		},
-		"begin": "2024-12-21",
-		"end": "2025-01-06"
-	},
-	{
-		"name": {
-			"de": "Notenmeldung Prädikate (ZV)",
-			"en": "Recording grades predicates (admission requirements)"
-		},
-		"begin": "2025-01-08T9:00",
-		"hasHours": true
-	},
-	{
-		"name": {
-			"de": "Rückmeldung zum Sommersemester 2025",
-			"en": "Re-registration for summer semester 2025"
-		},
-		"begin": "2025-01-14",
-		"end": "2025-01-31"
-	},
-	{
-		"name": {
-			"de": "Erweiterter Prüfungszeitraum",
-			"en": "Additional exam period"
-		},
-		"begin": "2025-01-18",
-		"end": "2025-01-24"
-	},
-	{
-		"name": {
-			"de": "Ende der Vorlesungszeit",
-			"en": "End of lecture period"
-		},
-		"begin": "2025-01-24"
-	},
-	{
-		"name": {
-			"de": "Prüfungszeitraum",
-			"en": "Exam period"
-		},
-		"begin": "2025-01-25",
-		"end": "2025-02-04"
-	},
-	{
-		"name": {
-			"de": "Notenmeldung",
-			"en": "Recording grades"
-		},
-		"begin": "2025-02-10T9:00",
-		"hasHours": true
-	},
-	{
-		"name": {
-			"de": "Notenbekanntgabe",
-			"en": "Announcement of grades"
-		},
-		"begin": "2025-02-14T13:00",
-		"hasHours": true
-	},
-	{
-		"name": {
-			"de": "Semesterferien",
-			"en": "Semester break"
-		},
-		"begin": "2025-02-15",
-		"end": "2025-03-14"
-	},
-	{
-		"name": {
 			"de": "Vorlesungsbeginn und Semesterstart",
 			"en": "Start of lectures and semester"
 		},
@@ -275,5 +117,184 @@
 		},
 		"begin": "2025-08-01",
 		"end": "2025-09-30"
+	},
+	{
+		"name": {
+			"de": "Vorlesungsbeginn und Semesterstart",
+			"en": "Start of lectures and semester"
+		},
+		"begin": "2025-10-01"
+	},
+	{
+		"name": {
+			"de": "Vorlesungsfrei (Allerheiligen)",
+			"en": "No lectures (All Saints´ Day)"
+		},
+		"begin": "2025-11-01"
+	},
+	{
+		"name": {
+			"de": "Prüfungsanmeldung",
+			"en": "Registration for exams"
+		},
+		"begin": "2025-11-04",
+		"end": "2025-11-13"
+	},
+	{
+		"name": {
+			"de": "Prüfungsabmeldung",
+			"en": "Deregistration for exams"
+		},
+		"begin": "2025-11-14",
+		"end": "2026-01-08"
+	},
+	{
+		"name": {
+			"de": "Vorlesungsfrei (Weihnachten)",
+			"en": "No lectures (Christmas)"
+		},
+		"begin": "2025-12-21",
+		"end": "2026-01-06"
+	},
+	{
+		"name": {
+			"de": "Rückmeldung zum Sommersemester 2026",
+			"en": "Re-registration for summer semester 2026"
+		},
+		"begin": "2026-01-14",
+		"end": "2026-01-31"
+	},
+	{
+		"name": {
+			"de": "Erweiterter Prüfungszeitraum",
+			"en": "Additional exam period"
+		},
+		"begin": "2026-01-17",
+		"end": "2026-01-23"
+	},
+	{
+		"name": {
+			"de": "Ende der Vorlesungszeit",
+			"en": "End of lecture period"
+		},
+		"begin": "2026-01-23"
+	},
+	{
+		"name": {
+			"de": "Prüfungszeitraum",
+			"en": "Exam period"
+		},
+		"begin": "2026-01-24",
+		"end": "2026-02-04"
+	},
+	{
+		"name": {
+			"de": "Notenbekanntgabe",
+			"en": "Announcement of grades"
+		},
+		"begin": "2026-02-13T13:00",
+		"hasHours": true
+	},
+	{
+		"name": {
+			"de": "Semesterferien",
+			"en": "Semester break"
+		},
+		"begin": "2026-02-14",
+		"end": "2026-03-14"
+	},
+	{
+		"name": {
+			"de": "Vorlesungsbeginn und Semesterstart",
+			"en": "Start of lectures and semester"
+		},
+		"begin": "2026-03-16"
+	},
+	{
+		"name": {
+			"de": "Vorlesungsfrei (Ostern)",
+			"en": "No lectures (Easter)"
+		},
+		"begin": "2026-04-02",
+		"end": "2026-04-07"
+	},
+	{
+		"name": {
+			"de": "Prüfungsanmeldung",
+			"en": "Registration for exams"
+		},
+		"begin": "2026-04-28",
+		"end": "2026-05-07"
+	},
+	{
+		"name": {
+			"de": "Prüfungsabmeldung",
+			"en": "Deregistration for exams"
+		},
+		"begin": "2026-05-08",
+		"end": "2025-06-25"
+	},
+	{
+		"name": {
+			"de": "Vorlesungsfrei (Pfingsten)",
+			"en": "No lectures (Whitsun)"
+		},
+		"begin": "2026-05-22",
+		"end": "2026-05-26"
+	},
+	{
+		"name": {
+			"de": "Vorlesungsfrei (Fronleichnam, Brückentag)",
+			"en": "No lectures (Corpus Christi, Bridge Day)"
+		},
+		"begin": "2026-06-04",
+		"end": "2026-06-05"
+	},
+	{
+		"name": {
+			"de": "Rückmeldung zum Wintersemester 2026/20267",
+			"en": "Re-registration for winter semester 2026/2027"
+		},
+		"begin": "2026-07-02",
+		"end": "2026-08-07"
+	},
+	{
+		"name": {
+			"de": "Erweiterter Prüfungszeitraum",
+			"en": "Additional exam period"
+		},
+		"begin": "2026-07-04",
+		"end": "2026-07-10"
+	},
+	{
+		"name": {
+			"de": "Ende der Vorlesungszeit",
+			"en": "End of lecture period"
+		},
+		"begin": "2026-07-10"
+	},
+	{
+		"name": {
+			"de": "Prüfungszeitraum",
+			"en": "Exam period"
+		},
+		"begin": "2026-07-11",
+		"end": "2026-07-22"
+	},
+	{
+		"name": {
+			"de": "Notenbekanntgabe",
+			"en": "Announcement of grades"
+		},
+		"begin": "2026-07-31T13:00",
+		"hasHours": true
+	},
+	{
+		"name": {
+			"de": "Semesterferien",
+			"en": "Semester break"
+		},
+		"begin": "2026-08-01",
+		"end": "2026-09-30"
 	}
 ]


### PR DESCRIPTION
Please tripple check the correctness of the data:
[Semestertermine](https://www.thi.de/studium/semestertermine/)

Note: The end date of `No lectures (Whitsun)` seems to be wrong in the pdf. I have already informed the THI and used the correct value in the json.