### PR TITLE
fix: display of long location text

### DIFF
--- a/src/components/Universal/EventItem.tsx
+++ b/src/components/Universal/EventItem.tsx
@@ -74,7 +74,14 @@ const EventItem = ({
 						</Text>
 					</View>
 					{location && (
-						<View style={{ flexDirection: 'row', alignItems: 'center', flexShrink: 1, marginLeft: 8 }}>
+						<View
+							style={{
+								flexDirection: 'row',
+								alignItems: 'center',
+								flexShrink: 1,
+								marginLeft: 8
+							}}
+						>
 							<Text style={styles.eventLocation} numberOfLines={1}>
 								{location}
 							</Text>

--- a/src/components/Universal/EventItem.tsx
+++ b/src/components/Universal/EventItem.tsx
@@ -74,7 +74,7 @@ const EventItem = ({
 						</Text>
 					</View>
 					{location && (
-						<View style={{ flexDirection: 'row', alignItems: 'center' }}>
+						<View style={{ flexDirection: 'row', alignItems: 'center', flexShrink: 1, marginLeft: 8 }}>
 							<Text style={styles.eventLocation} numberOfLines={1}>
 								{location}
 							</Text>


### PR DESCRIPTION
## 📋 Description

Fix the display of long location text in event cards.

## ✅ Checklist

- [x] I’ve tested my changes on iOS
- [x] I’ve tested my changes on Android
- [x] I’ve tested my changes on Web

- [ ] I’ve added or updated documentation (if needed)
- [ ] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

<!-- Anything else reviewers should be aware of? -->
