### PR TITLE
feat: add showSplashScreen preference and integrate into splash behavior

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
         "graphql": "^16.11.0",
         "i18next": "^25.2.1",
         "idb": "^8.0.3",
-        "lucide-react-native": "0.511.0",
+        "lucide-react-native": "0.513.0",
         "maplibre-gl": "^5.5.0",
         "metro": "^0.82.0",
         "moment": "^2.30.1",
@@ -2013,7 +2013,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react-native": ["lucide-react-native@0.511.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-native": "*", "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0" } }, "sha512-brCrakogilGx3inT0em8HUU11dsxyu62+P6sjqU7WKgkfcIc8Q0Ya3zDcBQ8EG3c1HsCSvgFT5tWLetVFAsqhQ=="],
+    "lucide-react-native": ["lucide-react-native@0.513.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-native": "*", "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0" } }, "sha512-S3A4PSEGbZkvHKro6jkmgOBswxd+IYdnfr+xRqPlJHjfqRccTrj0dK5cGQzgLVmXD0e+oKZr17uRVcrr/RQVpw=="],
 
     "luxon": ["luxon@3.6.1", "", {}, "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ=="],
 

--- a/src/app/(screens)/theme.tsx
+++ b/src/app/(screens)/theme.tsx
@@ -5,11 +5,18 @@ import { createStyleSheet, useStyles } from 'react-native-unistyles'
 import MultiSectionRadio from '@/components/Food/FoodLanguageSection'
 import ThemePreview from '@/components/Theme/ThemePreview'
 import SectionView from '@/components/Universal/SectionsView'
+import SingleSectionPicker from '@/components/Universal/SingleSectionPicker'
 import { usePreferencesStore } from '@/hooks/usePreferencesStore'
 
 export default function Theme(): React.JSX.Element {
 	const theme = usePreferencesStore((state) => state.theme)
 	const setTheme = usePreferencesStore((state) => state.setTheme)
+	const showSplashScreen = usePreferencesStore(
+		(state) => state.showSplashScreen
+	)
+	const setShowSplashScreen = usePreferencesStore(
+		(state) => state.setShowSplashScreen
+	)
 	const { t } = useTranslation(['settings', 'timetable'])
 	const { styles } = useStyles(stylesheet)
 
@@ -30,12 +37,6 @@ export default function Theme(): React.JSX.Element {
 
 	return (
 		<View style={styles.container}>
-			<View style={styles.preview}>
-				<Text style={styles.previewLabel}>
-					{t('timetable:preferences.preview')}
-				</Text>
-				<ThemePreview theme={theme ?? 'auto'} onThemeChange={setTheme} />
-			</View>
 			<SectionView
 				title={t('theme.themes.title')}
 				footer={t('theme.themes.footer')}
@@ -46,6 +47,23 @@ export default function Theme(): React.JSX.Element {
 					action={setTheme as (item: string) => void}
 				/>
 			</SectionView>
+			<SectionView
+				title={t('settings:theme.splash.title')}
+				footer={t('settings:theme.splash.footer')}
+			>
+				<SingleSectionPicker
+					title={t('settings:theme.splash.showSplash')}
+					selectedItem={showSplashScreen}
+					action={setShowSplashScreen}
+					state={showSplashScreen}
+				/>
+			</SectionView>
+			<View style={styles.preview}>
+				<Text style={styles.previewLabel}>
+					{t('timetable:preferences.preview')}
+				</Text>
+				<ThemePreview theme={theme ?? 'auto'} onThemeChange={setTheme} />
+			</View>
 		</View>
 	)
 }
@@ -57,7 +75,7 @@ const stylesheet = createStyleSheet((theme) => ({
 	},
 	preview: {
 		marginHorizontal: theme.margins.page,
-		marginBottom: 12
+		marginTop: 42
 	},
 	previewLabel: {
 		color: theme.colors.labelSecondaryColor,

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -44,6 +44,7 @@ function RootLayout(): React.JSX.Element {
 	const isPad = DeviceInfo.isTablet()
 	const savedLanguage = usePreferencesStore((state) => state.language)
 	const presentationMode = usePresentationMode()
+
 	useQuickActionRouting()
 	useEffect(() => {
 		if (Platform.OS === 'web') {

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -12,6 +12,7 @@ import Animated, {
 } from 'react-native-reanimated'
 import Svg, { G, Path } from 'react-native-svg'
 import { UnistylesRuntime, useStyles } from 'react-native-unistyles'
+import { usePreferencesStore } from '@/hooks/usePreferencesStore'
 
 const AnimatedSvg = Animated.createAnimatedComponent(Svg)
 
@@ -50,6 +51,9 @@ export function Splash({ isReady, children }: React.PropsWithChildren<Props>) {
 	const { theme } = useStyles()
 	const [loaded, setLoaded] = useState(false)
 	const [hideSplash, setHideSplash] = useState(false)
+	const showSplashScreen = usePreferencesStore(
+		(state) => state.showSplashScreen
+	)
 
 	const intro = useSharedValue(0)
 	const introBackground = useSharedValue(0)
@@ -87,26 +91,30 @@ export function Splash({ isReady, children }: React.PropsWithChildren<Props>) {
 	useEffect(() => {
 		if (isReady && loaded) {
 			SplashScreen.hideAsync()
-			intro.value = withTiming(0.2, { duration: 100 }, () => {
-				intro.value = withTiming(0.4, { duration: 200 }, () => {
-					intro.value = withTiming(
-						1,
-						{ duration: 500, easing: Easing.out(Easing.exp) },
-						() => {
-							introBackground.value = withTiming(1, { duration: 200 }, () => {
-								runOnJS(setHideSplash)(true)
-							})
-						}
-					)
+			if (showSplashScreen) {
+				intro.value = withTiming(0.2, { duration: 100 }, () => {
+					intro.value = withTiming(0.4, { duration: 200 }, () => {
+						intro.value = withTiming(
+							1,
+							{ duration: 500, easing: Easing.out(Easing.exp) },
+							() => {
+								introBackground.value = withTiming(1, { duration: 200 }, () => {
+									runOnJS(setHideSplash)(true)
+								})
+							}
+						)
+					})
 				})
-			})
+			} else {
+				setHideSplash(true)
+			}
 		}
-	}, [isReady, loaded])
+	}, [isReady, loaded, showSplashScreen])
 
 	return (
 		<View style={StyleSheet.absoluteFill}>
 			{children}
-			{!hideSplash && Platform.OS !== 'web' && (
+			{!hideSplash && Platform.OS !== 'web' && showSplashScreen && (
 				<>
 					<Animated.View
 						style={[StyleSheet.absoluteFill, animatedBackgroundStyle]}

--- a/src/components/provider.tsx
+++ b/src/components/provider.tsx
@@ -64,6 +64,9 @@ export default function Provider({
 	useOnlineManager()
 	useAppState(onAppStateChange)
 	const theme = usePreferencesStore((state) => state.theme)
+	const showSplashScreen = usePreferencesStore(
+		(state) => state.showSplashScreen
+	)
 	const timetableMode = useTimetableStore((state) => state.timetableMode)
 	const appIcon = usePreferencesStore((state) => state.appIcon)
 	const selectedRestaurants = useFoodFilterStore(
@@ -100,6 +103,15 @@ export default function Provider({
 			theme: theme
 		})
 	}, [theme, analyticsInitialized])
+
+	useEffect(() => {
+		if (!analyticsInitialized) {
+			return
+		}
+		trackEvent('SplashScreen', {
+			showSplashScreen: showSplashScreen
+		})
+	}, [showSplashScreen, analyticsInitialized])
 
 	useEffect(() => {
 		if (!analyticsInitialized) {

--- a/src/data/licenses.json
+++ b/src/data/licenses.json
@@ -298,7 +298,7 @@
 		"licenseUrl": "https://github.com/jakearchibald/idb/raw/master/LICENSE",
 		"parents": "neuland"
 	},
-	"lucide-react-native@0.511.0": {
+	"lucide-react-native@0.513.0": {
 		"licenses": "ISC",
 		"repository": "https://github.com/lucide-icons/lucide",
 		"licenseUrl": "https://github.com/lucide-icons/lucide/raw/master/LICENSE",

--- a/src/hooks/usePreferencesStore.ts
+++ b/src/hooks/usePreferencesStore.ts
@@ -9,11 +9,13 @@ interface PreferencesStore {
 	appIcon: string | undefined
 	unlockedAppIcons: string[]
 	recentQuicklinks: string[]
+	showSplashScreen: boolean
 	setTheme: (theme: string) => void
 	setLanguage: (language: 'en' | 'de') => void
 	setAppIcon: (name: string) => void
 	addUnlockedAppIcon: (name: string) => void
 	addRecentQuicklink: (quicklink: string) => void
+	setShowSplashScreen: (show: boolean) => void
 	reset: () => void
 }
 
@@ -25,12 +27,14 @@ const initialState: Omit<
 	| 'addRecentQuicklink'
 	| 'reset'
 	| 'setLanguage'
+	| 'setShowSplashScreen'
 > = {
 	appIcon: undefined,
 	language: undefined,
 	theme: 'auto',
 	unlockedAppIcons: [],
-	recentQuicklinks: defaultQuicklinks
+	recentQuicklinks: defaultQuicklinks,
+	showSplashScreen: true
 }
 
 export const usePreferencesStore = create<PreferencesStore>()(
@@ -45,6 +49,9 @@ export const usePreferencesStore = create<PreferencesStore>()(
 			},
 			setAppIcon: (appIcon: string) => {
 				set({ appIcon })
+			},
+			setShowSplashScreen: (showSplashScreen: boolean) => {
+				set({ showSplashScreen })
 			},
 			addUnlockedAppIcon: (name: string) => {
 				set((state) => {

--- a/src/localization/de/settings.json
+++ b/src/localization/de/settings.json
@@ -161,6 +161,11 @@
 			"dark": "Dunkel",
 			"light": "Hell",
 			"footer": "Ändere das Farbschema der App. Dies ermöglicht es dir, die Systemeinstellungen zu überschreiben."
+		},
+		"splash": {
+			"title": "Startbildschirm",
+			"footer": "Aktiviere oder deaktiviere den animierten Startbildschirm beim Öffnen der App",
+			"showSplash": "Animierten Startbildschirm anzeigen"
 		}
 	},
 	"dashboard": {

--- a/src/localization/en/settings.json
+++ b/src/localization/en/settings.json
@@ -182,6 +182,11 @@
 			"dark": "Dark",
 			"light": "Light",
 			"footer": "Change color scheme of the app. This allows you to override the system settings."
+		},
+		"splash": {
+			"title": "Splash Screen",
+			"footer": "Enable or disable the animated splash screen when opening the app",
+			"showSplash": "Show Animated Splash Screen"
 		}
 	},
 	"dashboard": {


### PR DESCRIPTION
## 📋 Description

This pull request introduces functionality to toggle the animated splash screen in the app's settings, updates the app's theme screen layout, and modifies localization files to support the new feature. The most important changes are grouped below:

### Splash Screen Toggle Feature
* Added a `showSplashScreen` property and its corresponding setter (`setShowSplashScreen`) to the `PreferencesStore` in `usePreferencesStore`. The initial state defaults to `true`. (`src/hooks/usePreferencesStore.ts`) [[1]](diffhunk://#diff-74e66029393fba299832459b6e434ce6f03a11a236a2611f12f2dc9c75a7eaefR12-R18) [[2]](diffhunk://#diff-74e66029393fba299832459b6e434ce6f03a11a236a2611f12f2dc9c75a7eaefR30-R37) [[3]](diffhunk://#diff-74e66029393fba299832459b6e434ce6f03a11a236a2611f12f2dc9c75a7eaefR53-R55)
* Updated the `Splash` component to conditionally render the splash screen based on the `showSplashScreen` preference. (`src/components/Splash.tsx`) [[1]](diffhunk://#diff-ee665acd24d74974e020b2fe097e628e0872a414bd6fa007f50be19aba3aca42R54-R56) [[2]](diffhunk://#diff-ee665acd24d74974e020b2fe097e628e0872a414bd6fa007f50be19aba3aca42R94) [[3]](diffhunk://#diff-ee665acd24d74974e020b2fe097e628e0872a414bd6fa007f50be19aba3aca42R108-R117)
* Added analytics tracking for the splash screen toggle in the `Provider` component. (`src/components/provider.tsx`)

### Theme Screen Updates
* Reorganized the theme screen layout to include a new section for toggling the splash screen. This involved adding a `SingleSectionPicker` component and moving the theme preview section. (`src/app/(screens)/theme.tsx`) [[1]](diffhunk://#diff-8aa67c7ce6f37a7a34f46ee566fa40c67d6908749e2cd6e1812f92b4fbcfe1bdR8-R19) [[2]](diffhunk://#diff-8aa67c7ce6f37a7a34f46ee566fa40c67d6908749e2cd6e1812f92b4fbcfe1bdL33-L38) [[3]](diffhunk://#diff-8aa67c7ce6f37a7a34f46ee566fa40c67d6908749e2cd6e1812f92b4fbcfe1bdR50-R66)
* Adjusted the `preview` style to add a `marginTop` instead of `marginBottom`. (`src/app/(screens)/theme.tsx`)

### Localization
* Added new localization keys for the splash screen toggle in both English and German settings files. (`src/localization/en/settings.json`, `src/localization/de/settings.json`) [[1]](diffhunk://#diff-a33cfda024e49c54bef2118892be74dce7ee47199863a849e11d5d09b22ed373R185-R189) [[2]](diffhunk://#diff-22be281a72ae576768028136c81659c9f780e2d7286bd767fcf8ce76d1d7a460R164-R168)

## ✅ Checklist

- [x] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android