### PR TITLE
fix: improve showSplashScreen behavior

### DIFF
--- a/src/app/(screens)/theme.tsx
+++ b/src/app/(screens)/theme.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Text, View } from 'react-native'
+import { Platform, Text, View } from 'react-native'
 import { createStyleSheet, useStyles } from 'react-native-unistyles'
 import MultiSectionRadio from '@/components/Food/FoodLanguageSection'
 import ThemePreview from '@/components/Theme/ThemePreview'
@@ -47,17 +47,19 @@ export default function Theme(): React.JSX.Element {
 					action={setTheme as (item: string) => void}
 				/>
 			</SectionView>
-			<SectionView
-				title={t('settings:theme.splash.title')}
-				footer={t('settings:theme.splash.footer')}
-			>
-				<SingleSectionPicker
-					title={t('settings:theme.splash.showSplash')}
-					selectedItem={showSplashScreen}
-					action={setShowSplashScreen}
-					state={showSplashScreen}
-				/>
-			</SectionView>
+			{Platform.OS !== 'web' && (
+				<SectionView
+					title={t('settings:theme.splash.title')}
+					footer={t('settings:theme.splash.footer')}
+				>
+					<SingleSectionPicker
+						title={t('settings:theme.splash.showSplash')}
+						selectedItem={showSplashScreen}
+						action={setShowSplashScreen}
+						state={showSplashScreen}
+					/>
+				</SectionView>
+			)}
 			<View style={styles.preview}>
 				<Text style={styles.previewLabel}>
 					{t('timetable:preferences.preview')}

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -168,6 +168,15 @@ function RootLayout(): React.JSX.Element {
 						gestureEnabled: false
 					}}
 				/>
+				<Stack.Screen
+					name="index"
+					options={{
+						title: 'Home',
+						headerShown: false,
+						animation: 'none',
+						gestureEnabled: false
+					}}
+				/>
 
 				<Stack.Screen
 					name="(screens)/login"

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -70,16 +70,18 @@ export function Splash({ isReady, children }: React.PropsWithChildren<Props>) {
 		Platform.OS === 'ios' ? { marginLeft: -iosXShift / 2 } : {}
 
 	const animatedLogoStyle = useAnimatedStyle(() => ({
-		transform: [
-			{
-				scale: interpolate(
-					intro.value,
-					[0, 0.2, 0.4, 1],
-					[1, 1, 0.8, 10],
-					'clamp'
-				)
-			}
-		],
+		transform: showSplashScreen
+			? [
+					{
+						scale: interpolate(
+							intro.value,
+							[0, 0.2, 0.4, 1],
+							[1, 1, 0.8, 10],
+							'clamp'
+						)
+					}
+				]
+			: [],
 		opacity: interpolate(intro.value, [0, 0.7, 0.8, 1], [1, 1, 0.4, 0], 'clamp')
 	}))
 
@@ -106,7 +108,15 @@ export function Splash({ isReady, children }: React.PropsWithChildren<Props>) {
 					})
 				})
 			} else {
-				setHideSplash(true)
+				intro.value = withTiming(
+					1,
+					{ duration: 500, easing: Easing.out(Easing.exp) },
+					() => {
+						introBackground.value = withTiming(1, { duration: 200 }, () => {
+							runOnJS(setHideSplash)(true)
+						})
+					}
+				)
 			}
 		}
 	}, [isReady, loaded, showSplashScreen])
@@ -114,7 +124,7 @@ export function Splash({ isReady, children }: React.PropsWithChildren<Props>) {
 	return (
 		<View style={StyleSheet.absoluteFill}>
 			{children}
-			{!hideSplash && Platform.OS !== 'web' && showSplashScreen && (
+			{!hideSplash && Platform.OS !== 'web' && (
 				<>
 					<Animated.View
 						style={[StyleSheet.absoluteFill, animatedBackgroundStyle]}

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -93,7 +93,7 @@ export function Splash({ isReady, children }: React.PropsWithChildren<Props>) {
 	const animateSplashWithTransformation = () => {
 		intro.value = withTiming(0.2, { duration: 100 }, () => {
 			intro.value = withTiming(0.4, { duration: 200 }, () => {
-				animateSplashFadeOut()
+				runOnJS(animateSplashFadeOut)()
 			})
 		})
 	}

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -90,33 +90,33 @@ export function Splash({ isReady, children }: React.PropsWithChildren<Props>) {
 		opacity: interpolate(introBackground.value, [0, 1], [1, 0], 'clamp')
 	}))
 
+	const animateSplashWithTransformation = () => {
+		intro.value = withTiming(0.2, { duration: 100 }, () => {
+			intro.value = withTiming(0.4, { duration: 200 }, () => {
+				animateSplashFadeOut()
+			})
+		})
+	}
+
+	const animateSplashFadeOut = () => {
+		intro.value = withTiming(
+			1,
+			{ duration: 500, easing: Easing.out(Easing.exp) },
+			() => {
+				introBackground.value = withTiming(1, { duration: 200 }, () => {
+					runOnJS(setHideSplash)(true)
+				})
+			}
+		)
+	}
+
 	useEffect(() => {
 		if (isReady && loaded) {
 			SplashScreen.hideAsync()
 			if (showSplashScreen) {
-				intro.value = withTiming(0.2, { duration: 100 }, () => {
-					intro.value = withTiming(0.4, { duration: 200 }, () => {
-						intro.value = withTiming(
-							1,
-							{ duration: 500, easing: Easing.out(Easing.exp) },
-							() => {
-								introBackground.value = withTiming(1, { duration: 200 }, () => {
-									runOnJS(setHideSplash)(true)
-								})
-							}
-						)
-					})
-				})
+				animateSplashWithTransformation()
 			} else {
-				intro.value = withTiming(
-					1,
-					{ duration: 500, easing: Easing.out(Easing.exp) },
-					() => {
-						introBackground.value = withTiming(1, { duration: 200 }, () => {
-							runOnJS(setHideSplash)(true)
-						})
-					}
-				)
+				animateSplashFadeOut()
 			}
 		}
 	}, [isReady, loaded, showSplashScreen])

--- a/src/localization/de/settings.json
+++ b/src/localization/de/settings.json
@@ -164,7 +164,7 @@
 		},
 		"splash": {
 			"title": "Startbildschirm",
-			"footer": "Aktiviere oder deaktiviere den animierten Startbildschirm beim Öffnen der App",
+			"footer": "Aktiviere oder deaktiviere den animierten Startbildschirm beim Öffnen der App.",
 			"showSplash": "Animierten Startbildschirm anzeigen"
 		}
 	},

--- a/src/localization/en/settings.json
+++ b/src/localization/en/settings.json
@@ -185,7 +185,7 @@
 		},
 		"splash": {
 			"title": "Splash Screen",
-			"footer": "Enable or disable the animated splash screen when opening the app",
+			"footer": "Enable or disable the animated splash screen when opening the app.",
 			"showSplash": "Show Animated Splash Screen"
 		}
 	},


### PR DESCRIPTION
## 📋 Description

Since the showSplashScreen feature is one of the most important parts of the app, I have made a few improvements.

If I currently start the app without the splash screen, it looks like the screenshots show:
![Step 1](https://github.com/user-attachments/assets/cf894247-908a-4f85-8aa3-7213768776a0)
![Step 2](https://github.com/user-attachments/assets/9779f2fc-6594-41ad-b9ab-3474bafa215c)
![Step 3](https://github.com/user-attachments/assets/2f233b94-e5b9-49fb-a870-fee33172c813)

Opening the start screen is not smooth and very jerky.
So I added the following improvements:
- Always show the Logo and Background Fade Out Animation on the Splash Screen
- Hide the Splash Screen Toggle Settings for Web Users
- Harmonize Locales of Splash Screen Preferences

I could only test my changes on the web because I am somehow too stupid to set up a proper development environment.

I know, there are a lot of commits. I will squash them on request.

## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [x] I’ve tested my changes on Web

## 🗒️ Additional Notes

I am not a real web developer. Please bear with me.
I also don't know how to properly resize my Screenshots.
