### PR TITLE
feat: add no data handling to BaseCard and CareerCard

### DIFF
--- a/src/components/Cards/BaseCard.tsx
+++ b/src/components/Cards/BaseCard.tsx
@@ -113,16 +113,13 @@ const BaseCard: React.FC<BaseCardProps> = ({
 						/>
 					)}
 				</View>
-				{/* Render either children or noDataComponent based on noDataPredicate */}
-				{noDataPredicate != null && noDataPredicate() ? (
-					noDataComponent != null && (
+				{noDataPredicate?.()
+					? noDataComponent != null && (
 						<View style={styles.childrenContainer}>{noDataComponent}</View>
 					)
-				) : (
-					children != null && (
+					: children != null && (
 						<View style={styles.childrenContainer}>{children}</View>
-					)
-				)}
+					)}
 			</View>
 		</View>
 	)
@@ -141,7 +138,7 @@ const BaseCard: React.FC<BaseCardProps> = ({
 						delayLongPress={300}
 						onPressIn={handlePressIn}
 						onPressOut={handlePressOut}
-						onLongPress={() => {}}
+						onLongPress={() => { }}
 						style={styles.pressable}
 					>
 						{cardContent}

--- a/src/components/Cards/BaseCard.tsx
+++ b/src/components/Cards/BaseCard.tsx
@@ -115,11 +115,11 @@ const BaseCard: React.FC<BaseCardProps> = ({
 				</View>
 				{noDataPredicate?.()
 					? noDataComponent != null && (
-						<View style={styles.childrenContainer}>{noDataComponent}</View>
-					)
+							<View style={styles.childrenContainer}>{noDataComponent}</View>
+						)
 					: children != null && (
-						<View style={styles.childrenContainer}>{children}</View>
-					)}
+							<View style={styles.childrenContainer}>{children}</View>
+						)}
 			</View>
 		</View>
 	)
@@ -138,7 +138,7 @@ const BaseCard: React.FC<BaseCardProps> = ({
 						delayLongPress={300}
 						onPressIn={handlePressIn}
 						onPressOut={handlePressOut}
-						onLongPress={() => { }}
+						onLongPress={() => {}}
 						style={styles.pressable}
 					>
 						{cardContent}

--- a/src/components/Cards/BaseCard.tsx
+++ b/src/components/Cards/BaseCard.tsx
@@ -22,12 +22,16 @@ interface BaseCardProps {
 	title: string
 	onPressRoute?: Href
 	children?: React.ReactNode
+	noDataComponent?: React.ReactNode
+	noDataPredicate?: () => boolean
 }
 
 const BaseCard: React.FC<BaseCardProps> = ({
 	title,
 	onPressRoute,
-	children
+	children,
+	noDataComponent,
+	noDataPredicate
 }) => {
 	const { styles } = useStyles(stylesheet)
 	const { t } = useTranslation('navigation')
@@ -112,6 +116,11 @@ const BaseCard: React.FC<BaseCardProps> = ({
 				{children != null && (
 					<View style={styles.childrenContainer}>{children}</View>
 				)}
+				{noDataComponent != null &&
+					noDataPredicate != null &&
+					noDataPredicate() && (
+						<View style={styles.childrenContainer}>{noDataComponent}</View>
+					)}
 			</View>
 		</View>
 	)

--- a/src/components/Cards/CareerCard.tsx
+++ b/src/components/Cards/CareerCard.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { router } from 'expo-router'
 import type React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform, Pressable, View } from 'react-native'
+import { Platform, Pressable, View, Text } from 'react-native'
 import { createStyleSheet, useStyles } from 'react-native-unistyles'
 import { getFragmentData } from '@/__generated__/gql'
 import {
@@ -97,8 +97,20 @@ const CareerCard = (): React.JSX.Element => {
 		})
 	}
 
+	const noData = (
+		<Text style={styles.noDataTitle}>{t('error.noData.title')}</Text>
+	)
+
 	return (
-		<BaseCard title="thiServices" onPressRoute="/thi-services">
+		<BaseCard
+			title="thiServices"
+			onPressRoute="/thi-services"
+			noDataComponent={noData}
+			noDataPredicate={() =>
+				careerServiceEvents.length === 0 &&
+				studentCounsellingEvents.length === 0
+			}
+		>
 			<View style={styles.eventsContainer}>
 				{careerServiceEvents[0] && (
 					<Pressable
@@ -141,10 +153,15 @@ const CareerCard = (): React.JSX.Element => {
 	)
 }
 
-const stylesheet = createStyleSheet(() => ({
+const stylesheet = createStyleSheet((theme) => ({
 	eventsContainer: {
 		marginTop: 10,
 		gap: 12
+	},
+	noDataTitle: {
+		color: theme.colors.text,
+		fontSize: 16,
+		fontWeight: '500'
 	}
 }))
 

--- a/src/components/Cards/CareerCard.tsx
+++ b/src/components/Cards/CareerCard.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { router } from 'expo-router'
 import type React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform, Pressable, View, Text } from 'react-native'
+import { Platform, Pressable, Text, View } from 'react-native'
 import { createStyleSheet, useStyles } from 'react-native-unistyles'
 import { getFragmentData } from '@/__generated__/gql'
 import {
@@ -107,6 +107,8 @@ const CareerCard = (): React.JSX.Element => {
 			onPressRoute="/thi-services"
 			noDataComponent={noData}
 			noDataPredicate={() =>
+				careerServiceQuery.isSuccess &&
+				studentCounsellingQuery.isSuccess &&
 				careerServiceEvents.length === 0 &&
 				studentCounsellingEvents.length === 0
 			}

--- a/src/components/Cards/EventsCard.tsx
+++ b/src/components/Cards/EventsCard.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { router } from 'expo-router'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform, Pressable, View } from 'react-native'
+import { Platform, Pressable, Text, View } from 'react-native'
 import { createStyleSheet, useStyles } from 'react-native-unistyles'
 import type { LanguageKey } from '@/localization/i18n'
 import { loadCampusLifeEvents, QUERY_KEYS } from '@/utils/events-utils'
@@ -12,6 +12,7 @@ import BaseCard from './BaseCard'
 const EventsCard = (): React.JSX.Element => {
 	const { theme, styles } = useStyles(stylesheet)
 	const { i18n } = useTranslation('navigation')
+	const { t } = useTranslation('common')
 	const { data, isSuccess } = useQuery({
 		queryKey: [QUERY_KEYS.CAMPUS_LIFE_EVENTS],
 		queryFn: loadCampusLifeEvents,
@@ -36,8 +37,17 @@ const EventsCard = (): React.JSX.Element => {
 		}
 	}
 
+	const noData = (
+		<Text style={styles.noDataTitle}>{t('error.noData.title')}</Text>
+	)
+
 	return (
-		<BaseCard title="events" onPressRoute="/cl-events">
+		<BaseCard
+			title="events"
+			onPressRoute="/cl-events"
+			noDataComponent={noData}
+			noDataPredicate={() => isSuccess && data.length === 0}
+		>
 			{Boolean(isSuccess) && data !== undefined && (
 				<View style={styles.eventsContainer}>
 					{data.slice(0, 2).map((event, index) => (
@@ -70,6 +80,11 @@ const stylesheet = createStyleSheet((theme) => ({
 		marginTop: 10,
 		gap: 12,
 		borderColor: theme.colors.border
+	},
+	noDataTitle: {
+		color: theme.colors.text,
+		fontSize: 16,
+		fontWeight: '500'
 	}
 }))
 

--- a/src/components/Cards/NewsCard.tsx
+++ b/src/components/Cards/NewsCard.tsx
@@ -12,9 +12,10 @@ import BaseCard from './BaseCard'
 const NewsCard: React.FC = () => {
 	const ref = useRef(null)
 	const { t } = useTranslation('navigation')
+	const { t: tCommon } = useTranslation('common')
 	const { styles } = useStyles(stylesheet)
 	const { userKind = USER_GUEST } = use(UserKindContext)
-	const { data } = useQuery({
+	const { data, isSuccess } = useQuery({
 		queryKey: ['thiNews'],
 		queryFn: async () => await API.getThiNews(),
 		staleTime: 1000 * 60 * 10, // 10 minutes
@@ -22,9 +23,18 @@ const NewsCard: React.FC = () => {
 		enabled: userKind !== USER_GUEST
 	})
 
+	const noData = (
+		<Text style={styles.noDataText}>{tCommon('error.noData.title')}</Text>
+	)
+
 	return (
 		<View ref={ref}>
-			<BaseCard title="news" onPressRoute="/news">
+			<BaseCard
+				title="news"
+				onPressRoute="/news"
+				noDataComponent={noData}
+				noDataPredicate={() => isSuccess && data.length === 0}
+			>
 				{data != null && data.length > 0 && (
 					<View style={styles.newsContainer}>
 						{data.slice(0, 2).map((newsItem, index) => (
@@ -95,6 +105,11 @@ const stylesheet = createStyleSheet((theme) => ({
 		color: theme.colors.labelColor,
 		fontSize: 14,
 		fontWeight: '500'
+	},
+	noDataText: {
+		color: theme.colors.text,
+		textAlign: 'center',
+		marginTop: 10
 	}
 }))
 

--- a/src/components/Cards/NewsCard.tsx
+++ b/src/components/Cards/NewsCard.tsx
@@ -11,8 +11,7 @@ import BaseCard from './BaseCard'
 
 const NewsCard: React.FC = () => {
 	const ref = useRef(null)
-	const { t } = useTranslation('navigation')
-	const { t: tCommon } = useTranslation('common')
+	const { t } = useTranslation(['navigation', 'common'])
 	const { styles } = useStyles(stylesheet)
 	const { userKind = USER_GUEST } = use(UserKindContext)
 	const { data, isSuccess } = useQuery({
@@ -24,7 +23,7 @@ const NewsCard: React.FC = () => {
 	})
 
 	const noData = (
-		<Text style={styles.noDataText}>{tCommon('error.noData.title')}</Text>
+		<Text style={styles.noDataText}>{t('common:error.noData.title')}</Text>
 	)
 
 	return (
@@ -62,7 +61,7 @@ const NewsCard: React.FC = () => {
 				{data != null && data.length > 3 && (
 					<View style={styles.cardsFilled}>
 						<Text style={styles.description}>
-							{t('cards.news.more', {
+							{t('navigation:cards.news.more', {
 								count: data.length
 							})}
 						</Text>


### PR DESCRIPTION
## 📋 Description

Add the option to show a "no data" component in BaseCard

<img width="314" alt="image" src="https://github.com/user-attachments/assets/9fbd2a6e-6392-47b1-86bb-1475eb8cf0b8" />

## ✅ Checklist

- [x] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web

- [ ] I’ve added or updated documentation (if needed)
- [ ] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

<!-- Anything else reviewers should be aware of? -->
