### PR TITLE
Fix getMonday return

### DIFF
--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -239,7 +239,7 @@ export function getMonday(date: Date): Date {
 	const day = newDate.getDay()
 	newDate.setHours(0, 0, 0, 0)
 	newDate.setDate(newDate.getDate() - day + (day === 0 ? -6 : 1))
-	return date
+	return newDate
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure `getMonday` returns the adjusted date

## Testing
- `bun run tsc --noEmit`
- `bun biome ci .`


------
https://chatgpt.com/codex/tasks/task_b_685707cb003c8326882aa3220a4199eb