### PR TITLE
Fix variable typo in drawable plugin

### DIFF
--- a/plugins/withDrawableAssets.js
+++ b/plugins/withDrawableAssets.js
@@ -16,7 +16,7 @@ const withDrawableAssets = (expoConfig, files) =>
 		'android',
 		(modConfig) => {
 			if (modConfig.modRequest.platform === 'android') {
-				const androidDwarablePath = join(
+				const androidDrawablePath = join(
 					modConfig.modRequest.platformProjectRoot,
 					...androidFolderPath
 				)
@@ -28,9 +28,9 @@ const withDrawableAssets = (expoConfig, files) =>
 				files.forEach((file) => {
 					const isFile = lstatSync(file).isFile()
 					if (isFile) {
-						copyFileSync(file, join(androidDwarablePath, basename(file)))
+						copyFileSync(file, join(androidDrawablePath, basename(file)))
 					} else {
-						copyFolderRecursiveSync(file, androidDwarablePath)
+						copyFolderRecursiveSync(file, androidDrawablePath)
 					}
 				})
 			}


### PR DESCRIPTION
## Summary
- fix a typo in the `withDrawableAssets` plugin
- keep formatting tidy

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68571115d4d88326a36b37222947e3cf