### PR TITLE
refactor: drop redundant faculty extraction function

### DIFF
--- a/src/app/(screens)/lecturers.tsx
+++ b/src/app/(screens)/lecturers.tsx
@@ -33,7 +33,7 @@ import { useRefreshByUser } from '@/hooks'
 import { Funktion, type Lecturers } from '@/types/thi-api'
 import type { NormalizedLecturer } from '@/types/utils'
 import {
-	extractFacultyFromPersonal,
+	extractFaculty,
 	getPersonalData,
 	guestError,
 	networkError
@@ -124,7 +124,7 @@ export default function LecturersScreen(): React.JSX.Element {
 
 	useEffect(() => {
 		if (data !== null && data !== undefined) {
-			const faculty = extractFacultyFromPersonal(data)
+			const faculty = extractFaculty(data)
 			setFaculty(faculty ?? null)
 		}
 	}, [data])

--- a/src/contexts/userKind.ts
+++ b/src/contexts/userKind.ts
@@ -1,10 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react'
 import { useMMKVString } from 'react-native-mmkv'
 import { USER_EMPLOYEE, USER_GUEST, USER_STUDENT } from '@/data/constants'
-import {
-	extractFacultyFromPersonalData,
-	getPersonalData
-} from '@/utils/api-utils'
+import { extractFaculty, getPersonalData } from '@/utils/api-utils'
 
 export interface UserKindContextType {
 	userKind: 'guest' | 'student' | 'employee' | undefined
@@ -33,10 +30,10 @@ export function useUserKind(): UserKindContextType {
 		const loadData = async (): Promise<void> => {
 			if (userFaculty === undefined && userKind === USER_STUDENT) {
 				const persData = await getPersonalData()
-				const faculty = extractFacultyFromPersonalData(persData)
+				const faculty = extractFaculty(persData)
 				setUserFaculty(faculty ?? undefined)
 
-				if (faculty === undefined) {
+				if (faculty === null) {
 					console.warn('Faculty could not be extracted from personal data')
 					setUserCampus(undefined)
 				} else {

--- a/src/utils/api-utils.ts
+++ b/src/utils/api-utils.ts
@@ -84,26 +84,6 @@ export async function getPersonalData(): Promise<PersDataDetails> {
 }
 
 /**
- * Determines the users faculty.
- * @param {PersonalData} data Personal data
- * @returns {string} Faculty name (e.g. `Informatik`)
- */
-export function extractFacultyFromPersonal(
-	data: PersDataDetails
-): string | undefined {
-	if (data?.stg == null) {
-		console.error('No personal data found')
-		return undefined
-	}
-	const shortNames: CourseShortNames = courseShortNames
-	const shortName = data.stg
-	const faculty = Object.keys(shortNames).find((faculty) =>
-		(courseShortNames as Record<string, string[]>)[faculty].includes(shortName)
-	)
-	return faculty
-}
-
-/**
  * Determines the users SPO version.
  * @param {PersonalDataDetails} data Personal data
  * @returns {string}
@@ -120,9 +100,9 @@ export function extractSpoName(data: PersDataDetails): string | null {
 /**
  * Determines the users faculty.
  * @param {PersonalData} data Personal data
- * @returns {string} Faculty name (e.g. `Informatik`)
+ * @returns {string} Faculty name (e.g. `Informatik`) or null
  */
-export function extractFacultyFromPersonalData(
+export function extractFaculty(
 	data: PersDataDetails | undefined
 ): string | null {
 	if (data?.stg == null) {


### PR DESCRIPTION
## Summary
- consolidate duplicate faculty helpers into `extractFaculty`
- update screens and context to use the new helper

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685710c8e51c83268d24fdd7bc270924