### PR TITLE
fix: add exam event types

### DIFF
--- a/src/components/Timetable/TimetableWeek.tsx
+++ b/src/components/Timetable/TimetableWeek.tsx
@@ -27,7 +27,11 @@ import {
 import useRouteParamsStore from '@/hooks/useRouteParamsStore'
 import { TimetableMode, useTimetableStore } from '@/hooks/useTimetableStore'
 import type { ITimetableViewProps } from '@/types/timetable'
-import type { Exam, FriendlyTimetableEntry } from '@/types/utils'
+import type {
+	Exam,
+	FriendlyExamEvent,
+	FriendlyTimetableEntry
+} from '@/types/utils'
 import { calendar } from '@/utils/calendar-utils'
 import LoadingIndicator from '../Universal/LoadingIndicator'
 import { HeaderRight } from './HeaderButtons'
@@ -164,8 +168,7 @@ export default function TimetableWeek({
 			})
 		)
 
-		// biome-ignore lint/suspicious/noExplicitAny: TODO
-		let friendlyExams: any[] = []
+		let friendlyExams: FriendlyExamEvent[] = []
 		if (showExams && exams.length > 0) {
 			friendlyExams = exams.map((entry, index) => {
 				const duration = Number(entry?.type?.match(/\d+/)?.[0] ?? 90)

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -17,6 +17,17 @@ export interface ExamEntry extends Exam {
 	endDate: Date
 }
 
+export interface FriendlyExamEvent extends Exam {
+	eventType: 'exam'
+	id: string
+	start: {
+		dateTime: Date
+	}
+	end: {
+		dateTime: Date
+	}
+}
+
 export interface FriendlyDateOptions {
 	weekday?: 'short' | 'long'
 	relative?: boolean


### PR DESCRIPTION
## Summary
- define `FriendlyExamEvent` interface for exam events
- use `FriendlyExamEvent[]` in TimetableWeek component

## Testing
- `npm run fmt`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68571130dad483269c43b0ab014db52f