### PR TITLE
fix: incorrect storage key

### DIFF
--- a/src/hooks/useFoodFilterStore.ts
+++ b/src/hooks/useFoodFilterStore.ts
@@ -91,7 +91,7 @@ export const useFoodFilterStore = create<FoodFilterStore>()(
 			},
 			reset: () => {
 				set({ ...initialState })
-				zustandStorage.removeItem('food-filter-store')
+				zustandStorage.removeItem('food-filter-storage')
 			}
 		}),
 		{


### PR DESCRIPTION
## Summary
- fix incorrect storage key name when resetting food filter store
- run bun fmt on the updated file

## Testing
- `bun fmt src/hooks/useFoodFilterStore.ts` *(fails: biome not installed)*
- `bun lint` *(fails: biome not installed)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685710ee76708325ae31a243c0bda1c3