### PR TITLE
fix: streamline query key for spoWeights

### DIFF
--- a/src/app/(screens)/grades.tsx
+++ b/src/app/(screens)/grades.tsx
@@ -88,7 +88,7 @@ export default function GradesSCreen(): React.JSX.Element {
 
 	// TODO: Just cache the spoWeights for the relevant study program
 	const { data: spoWeights, isLoading: isSpoLoading } = useQuery({
-		queryKey: ['spoWefights', packageInfo.version],
+		queryKey: ['spoWeights', packageInfo.version],
 		queryFn: async () => await NeulandAPI.getSpoWeights(),
 		staleTime: 1000 * 60 * 60 * 24 * 7, // 1 week
 		gcTime: 1000 * 60 * 60 * 24 * 14 // 2 weeks


### PR DESCRIPTION
## Summary
- correct typo in grades screen queryKey

## Testing
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_b_68571af58aac83269823de1fb9b9129d