### PR TITLE
feat(cl-events): add club following

### DIFF
--- a/src/__generated__/gql/gql.ts
+++ b/src/__generated__/gql/gql.ts
@@ -27,6 +27,7 @@ type Documents = {
     "\n    query CareerServiceEvents {\n        careerServiceEvents {\n            ...CareerServiceEventFields\n        }\n    }\n": typeof types.CareerServiceEventsDocument,
     "\n    fragment CareerServiceEventFields on CareerServiceEvent {\n        id\n        title\n        date\n        unlimitedSlots\n        availableSlots\n        totalSlots\n        waitingList\n        maxWaitingList\n        url\n    }\n": typeof types.CareerServiceEventFieldsFragmentDoc,
     "\n    query StudentCounsellingEvents {\n        studentCounsellingEvents {\n            ...StudentCounsellingEventFields\n        }\n    }\n": typeof types.StudentCounsellingEventsDocument,
+    "\n    query ClClubs {\n        clClubs {\n            name\n            website\n            instagram\n        }\n    }\n": typeof types.ClClubsDocument,
     "\n    fragment StudentCounsellingEventFields on StudentCounsellingEvent {\n        id\n        title\n        date\n        unlimitedSlots\n        availableSlots\n        totalSlots\n        waitingList\n        maxWaitingList\n        url\n    }\n": typeof types.StudentCounsellingEventFieldsFragmentDoc,
 };
 const documents: Documents = {
@@ -42,6 +43,7 @@ const documents: Documents = {
     "\n    query CareerServiceEvents {\n        careerServiceEvents {\n            ...CareerServiceEventFields\n        }\n    }\n": types.CareerServiceEventsDocument,
     "\n    fragment CareerServiceEventFields on CareerServiceEvent {\n        id\n        title\n        date\n        unlimitedSlots\n        availableSlots\n        totalSlots\n        waitingList\n        maxWaitingList\n        url\n    }\n": types.CareerServiceEventFieldsFragmentDoc,
     "\n    query StudentCounsellingEvents {\n        studentCounsellingEvents {\n            ...StudentCounsellingEventFields\n        }\n    }\n": types.StudentCounsellingEventsDocument,
+    "\n    query ClClubs {\n        clClubs {\n            name\n            website\n            instagram\n        }\n    }\n": types.ClClubsDocument,
     "\n    fragment StudentCounsellingEventFields on StudentCounsellingEvent {\n        id\n        title\n        date\n        unlimitedSlots\n        availableSlots\n        totalSlots\n        waitingList\n        maxWaitingList\n        url\n    }\n": types.StudentCounsellingEventFieldsFragmentDoc,
 };
 
@@ -93,6 +95,10 @@ export function graphql(source: "\n    fragment CareerServiceEventFields on Care
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n    query StudentCounsellingEvents {\n        studentCounsellingEvents {\n            ...StudentCounsellingEventFields\n        }\n    }\n"): typeof import('./graphql').StudentCounsellingEventsDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n    query ClClubs {\n        clClubs {\n            name\n            website\n            instagram\n        }\n    }\n"): typeof import('./graphql').ClClubsDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/src/__generated__/gql/graphql.ts
+++ b/src/__generated__/gql/graphql.ts
@@ -785,6 +785,11 @@ export type StudentCounsellingEventsQuery = { __typename?: 'Query', studentCouns
     & { ' $fragmentRefs'?: { 'StudentCounsellingEventFieldsFragment': StudentCounsellingEventFieldsFragment } }
   )> };
 
+export type ClClubsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ClClubsQuery = { __typename?: 'Query', clClubs: Array<{ __typename?: 'Host', name: string, website?: string | null, instagram?: string | null }> };
+
 export type StudentCounsellingEventFieldsFragment = { __typename?: 'StudentCounsellingEvent', id: string, title: string, date: Date, unlimitedSlots: boolean, availableSlots?: number | null, totalSlots?: number | null, waitingList?: number | null, maxWaitingList?: number | null, url?: string | null } & { ' $fragmentName'?: 'StudentCounsellingEventFieldsFragment' };
 
 export class TypedDocumentString<TResult, TVariables>
@@ -1138,3 +1143,12 @@ export const StudentCounsellingEventsDocument = new TypedDocumentString(`
   maxWaitingList
   url
 }`) as unknown as TypedDocumentString<StudentCounsellingEventsQuery, StudentCounsellingEventsQueryVariables>;
+export const ClClubsDocument = new TypedDocumentString(`
+    query ClClubs {
+  clClubs {
+    name
+    website
+    instagram
+  }
+}
+    `) as unknown as TypedDocumentString<ClClubsQuery, ClClubsQueryVariables>;

--- a/src/api/gql-documents.ts
+++ b/src/api/gql-documents.ts
@@ -201,6 +201,16 @@ export const STUDENT_ADVISORY_EVENTS_QUERY = graphql(/* GraphQL */ `
     }
 `)
 
+export const CL_CLUBS_QUERY = graphql(/* GraphQL */ `
+    query ClClubs {
+        clClubs {
+            name
+            website
+            instagram
+        }
+    }
+`)
+
 const STUDENT_ADVISORY_EVENTS_FRAGMENT = graphql(/* GraphQL */ `
     fragment StudentCounsellingEventFields on StudentCounsellingEvent {
         id

--- a/src/api/neuland-api.ts
+++ b/src/api/neuland-api.ts
@@ -3,6 +3,7 @@ import type {
 	AppAnnouncementsQuery,
 	CampusLifeEventsQuery,
 	CareerServiceEventsQuery,
+	ClClubsQuery,
 	CreateRoomReportMutation,
 	FoodPlanQuery,
 	RoomReportInput,
@@ -17,6 +18,7 @@ import {
 	ANNOUNCEMENT_QUERY,
 	CAMPUS_LIFE_EVENTS_QUERY,
 	CAREER_SERVICE_EVENTS_QUERY,
+	CL_CLUBS_QUERY,
 	CREATE_ROOM_REPORT,
 	FOOD_QUERY,
 	STUDENT_ADVISORY_EVENTS_QUERY,
@@ -108,6 +110,10 @@ class NeulandAPIClient {
 	 */
 	async getCampusLifeEvents(): Promise<CampusLifeEventsQuery> {
 		return await this.executeGql(CAMPUS_LIFE_EVENTS_QUERY)
+	}
+
+	async getCampusLifeClubs(): Promise<ClClubsQuery> {
+		return await this.executeGql(CL_CLUBS_QUERY)
 	}
 
 	/**

--- a/src/app/(screens)/cl-clubs.tsx
+++ b/src/app/(screens)/cl-clubs.tsx
@@ -1,0 +1,85 @@
+import { useQuery } from '@tanstack/react-query'
+import { useNavigation } from 'expo-router'
+import type React from 'react'
+import { startTransition, useLayoutEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ScrollView, View } from 'react-native'
+import { createStyleSheet, useStyles } from 'react-native-unistyles'
+import ErrorView from '@/components/Error/ErrorView'
+import LoadingIndicator from '@/components/Universal/LoadingIndicator'
+import MultiSectionPicker from '@/components/Universal/MultiSectionPicker'
+import SectionView from '@/components/Universal/SectionsView'
+import { useClubsStore } from '@/hooks/useClubsStore'
+import { networkError } from '@/utils/api-utils'
+import { loadCampusLifeClubs, QUERY_KEYS } from '@/utils/events-utils'
+
+export default function ClClubs(): React.JSX.Element {
+	const { styles } = useStyles(stylesheet)
+	const { t } = useTranslation('common')
+	const navigation = useNavigation()
+
+	useLayoutEffect(() => {
+		navigation.setOptions({ title: t('navigation.clubs') })
+	}, [navigation, t])
+
+	const { data, isLoading, isError, isPaused, isSuccess, refetch } = useQuery({
+		queryKey: [QUERY_KEYS.CAMPUS_LIFE_CLUBS],
+		queryFn: loadCampusLifeClubs,
+		staleTime: 1000 * 60 * 60,
+		gcTime: 1000 * 60 * 60 * 24
+	})
+
+	const followedClubs = useClubsStore((state) => state.followedClubs)
+	const toggleClub = useClubsStore((state) => state.toggleClub)
+
+	if (isLoading) {
+		return (
+			<View style={styles.centerContainer}>
+				<LoadingIndicator />
+			</View>
+		)
+	}
+
+	if (isError) {
+		return (
+			<ErrorView
+				title={t('error.title')}
+				onButtonPress={() => void refetch()}
+			/>
+		)
+	}
+
+	if (isPaused && !isSuccess) {
+		return <ErrorView title={networkError} />
+	}
+
+	const elements = (data ?? []).map((club) => ({
+		key: club.name,
+		title: club.name
+	}))
+
+	const handleToggle = (name: string) => {
+		startTransition(() => {
+			toggleClub(name)
+		})
+	}
+
+	return (
+		<ScrollView>
+			<View style={styles.container}>
+				<SectionView title={t('navigation.clubs')}>
+					<MultiSectionPicker
+						elements={elements}
+						selectedItems={followedClubs}
+						action={handleToggle}
+					/>
+				</SectionView>
+			</View>
+		</ScrollView>
+	)
+}
+
+const stylesheet = createStyleSheet((_theme) => ({
+	container: { flex: 1 },
+	centerContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' }
+}))

--- a/src/app/(screens)/cl-clubs.tsx
+++ b/src/app/(screens)/cl-clubs.tsx
@@ -3,9 +3,10 @@ import { useNavigation } from 'expo-router'
 import type React from 'react'
 import { startTransition, useLayoutEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ScrollView, View } from 'react-native'
+import { ScrollView, Text, View } from 'react-native'
 import { createStyleSheet, useStyles } from 'react-native-unistyles'
 import ErrorView from '@/components/Error/ErrorView'
+import PlatformIcon from '@/components/Universal/Icon'
 import LoadingIndicator from '@/components/Universal/LoadingIndicator'
 import MultiSectionPicker from '@/components/Universal/MultiSectionPicker'
 import SectionView from '@/components/Universal/SectionsView'
@@ -15,7 +16,7 @@ import { loadCampusLifeClubs, QUERY_KEYS } from '@/utils/events-utils'
 
 export default function ClClubs(): React.JSX.Element {
 	const { styles } = useStyles(stylesheet)
-	const { t } = useTranslation('common')
+	const { t } = useTranslation(['navigation', 'common'])
 	const navigation = useNavigation()
 
 	useLayoutEffect(() => {
@@ -43,7 +44,7 @@ export default function ClClubs(): React.JSX.Element {
 	if (isError) {
 		return (
 			<ErrorView
-				title={t('error.title')}
+				title={t('common:error.title')}
 				onButtonPress={() => void refetch()}
 			/>
 		)
@@ -67,6 +68,46 @@ export default function ClClubs(): React.JSX.Element {
 	return (
 		<ScrollView>
 			<View style={styles.container}>
+				<View style={styles.infoContainer}>
+					<Text style={styles.descriptionText}>
+						{t('common:pages.clEvents.clubs.description')}
+					</Text>
+					<View style={styles.benefitsContainer}>
+						<View style={styles.benefitRow}>
+							<PlatformIcon
+								ios={{ name: 'star.fill', size: 16 }}
+								android={{ name: 'star', size: 20 }}
+								web={{ name: 'Star', size: 16 }}
+								style={styles.benefitIcon}
+							/>
+							<Text style={styles.benefitText}>
+								{t('common:pages.clEvents.clubs.followInfo')}
+							</Text>
+						</View>
+						<View style={styles.benefitRow}>
+							<PlatformIcon
+								ios={{ name: 'calendar', size: 16 }}
+								android={{ name: 'calendar_today', size: 20 }}
+								web={{ name: 'Calendar', size: 16 }}
+								style={styles.benefitIcon}
+							/>
+							<Text style={styles.benefitText}>
+								{t('common:pages.clEvents.clubs.calendarInfo')}
+							</Text>
+						</View>
+						<View style={styles.benefitRow}>
+							<PlatformIcon
+								ios={{ name: 'sparkles', size: 16 }}
+								android={{ name: 'auto_awesome', size: 20 }}
+								web={{ name: 'Sparkles', size: 16 }}
+								style={styles.benefitIcon}
+							/>
+							<Text style={styles.benefitText}>
+								{t('common:pages.clEvents.clubs.priorityInfo')}
+							</Text>
+						</View>
+					</View>
+				</View>
 				<SectionView title={t('navigation.clubs')}>
 					<MultiSectionPicker
 						elements={elements}
@@ -79,7 +120,42 @@ export default function ClClubs(): React.JSX.Element {
 	)
 }
 
-const stylesheet = createStyleSheet((_theme) => ({
+const stylesheet = createStyleSheet((theme) => ({
 	container: { flex: 1 },
-	centerContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' }
+	centerContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+	infoContainer: {
+		marginHorizontal: theme.margins.page,
+		marginTop: 16,
+		marginBottom: 8,
+		paddingHorizontal: 16,
+		paddingVertical: 16,
+		backgroundColor: theme.colors.card,
+		borderRadius: theme.radius.md,
+		borderColor: theme.colors.border,
+		borderWidth: 1
+	},
+	descriptionText: {
+		color: theme.colors.text,
+		fontSize: 16,
+		lineHeight: 22,
+		marginBottom: 16,
+		fontWeight: '500'
+	},
+	benefitsContainer: {
+		gap: 8
+	},
+	benefitRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 8
+	},
+	benefitIcon: {
+		color: theme.colors.primary
+	},
+	benefitText: {
+		color: theme.colors.labelColor,
+		fontSize: 14,
+		lineHeight: 20,
+		flex: 1
+	}
 }))

--- a/src/app/(screens)/cl-events.tsx
+++ b/src/app/(screens)/cl-events.tsx
@@ -1,8 +1,20 @@
 import { trackEvent } from '@aptabase/react-native'
 import { useQueries } from '@tanstack/react-query'
-import { router, useFocusEffect, useLocalSearchParams } from 'expo-router'
+import {
+	router,
+	useFocusEffect,
+	useLocalSearchParams,
+	useNavigation
+} from 'expo-router'
 import type React from 'react'
-import { Suspense, useCallback, useEffect, useRef, useState } from 'react'
+import {
+	Suspense,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import {
 	Animated,
@@ -11,6 +23,7 @@ import {
 	View
 } from 'react-native'
 import { createStyleSheet, useStyles } from 'react-native-unistyles'
+import { ClEventsHeaderRight } from '@/components/Events/ClEventsHeaderRight'
 import ClEventsPage from '@/components/Events/ClEventsPage'
 import ClSportsPage from '@/components/Events/ClSportsPage'
 import PagerView from '@/components/Layout/PagerView'
@@ -26,11 +39,18 @@ import { pausedToast } from '@/utils/ui-utils'
 export default function Events(): React.JSX.Element {
 	const { t } = useTranslation('common')
 	const { styles } = useStyles(stylesheet)
+	const navigation = useNavigation()
 	const { tab, openEvent, id } = useLocalSearchParams<{
 		tab?: string
 		openEvent?: string
 		id?: string
 	}>()
+
+	useLayoutEffect(() => {
+		navigation.setOptions({
+			headerRight: () => <ClEventsHeaderRight />
+		})
+	}, [navigation])
 	const results = useQueries({
 		queries: [
 			{

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -356,7 +356,12 @@ function RootLayout(): React.JSX.Element {
 				<Stack.Screen
 					name="(screens)/cl-clubs"
 					options={{
-						title: t('navigation.clubs')
+						title: t('navigation.clubs'),
+						...Platform.select({
+							ios: {
+								presentation: 'modal'
+							}
+						})
 					}}
 				/>
 				<Stack.Screen

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -354,6 +354,12 @@ function RootLayout(): React.JSX.Element {
 					}}
 				/>
 				<Stack.Screen
+					name="(screens)/cl-clubs"
+					options={{
+						title: t('navigation.clubs')
+					}}
+				/>
+				<Stack.Screen
 					name="(screens)/events/counselling/[id]"
 					options={{
 						title: 'Event Details',

--- a/src/components/Events/ClEventsHeaderRight.tsx
+++ b/src/components/Events/ClEventsHeaderRight.tsx
@@ -1,0 +1,37 @@
+import { Link } from 'expo-router'
+import { useTranslation } from 'react-i18next'
+import { Platform, Pressable, View } from 'react-native'
+import { createStyleSheet, useStyles } from 'react-native-unistyles'
+import PlatformIcon from '@/components/Universal/Icon'
+
+export const ClEventsHeaderRight = (): React.JSX.Element => {
+	const { t } = useTranslation(['accessibility'])
+	const { styles } = useStyles(stylesheet)
+	return (
+		<Link asChild href="/cl-clubs">
+			<Pressable
+				hitSlop={10}
+				style={styles.headerButton}
+				accessibilityLabel={t('button.clubsFollow')}
+			>
+				<View>
+					<PlatformIcon
+						ios={{ name: 'person.2.fill', size: 22 }}
+						android={{ name: 'groups', size: 24 }}
+						web={{ name: 'Users', size: 24 }}
+						style={styles.icon}
+					/>
+				</View>
+			</Pressable>
+		</Link>
+	)
+}
+
+const stylesheet = createStyleSheet((theme) => ({
+	headerButton: {
+		marginHorizontal: Platform.OS !== 'ios' ? 14 : 0
+	},
+	icon: {
+		color: theme.colors.text
+	}
+}))

--- a/src/hooks/useClubsStore.ts
+++ b/src/hooks/useClubsStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+import { zustandStorage } from '@/utils/storage'
+
+interface ClubsStore {
+	followedClubs: string[]
+	toggleClub: (name: string) => void
+	reset: () => void
+}
+
+const initialState: Omit<ClubsStore, 'toggleClub' | 'reset'> = {
+	followedClubs: []
+}
+
+export const useClubsStore = create<ClubsStore>()(
+	persist(
+		(set) => ({
+			...initialState,
+			toggleClub: (name: string) => {
+				set((state) => {
+					const checked = state.followedClubs.includes(name)
+					const newSelection = state.followedClubs.filter((x) => x !== name)
+					if (!checked) {
+						newSelection.push(name)
+					}
+					return { followedClubs: newSelection }
+				})
+			},
+			reset: () => {
+				set({ ...initialState })
+				zustandStorage.removeItem('clubs-storage')
+			}
+		}),
+		{
+			name: 'clubs-storage',
+			storage: createJSONStorage(() => zustandStorage)
+		}
+	)
+)

--- a/src/localization/de/accessibility.json
+++ b/src/localization/de/accessibility.json
@@ -7,6 +7,7 @@
 		"settingsDashboard": "Dashboard Einstellungen",
 		"libraryBarcode": "Bibliotheksnummer als Barcode",
 		"previous": "Zurück",
+		"clubsFollow": "Vereine folgen",
 		"next": "Weiter"
 	}
 }

--- a/src/localization/de/common.json
+++ b/src/localization/de/common.json
@@ -326,6 +326,13 @@
 					"title": "Keine anstehenden Veranstaltungen",
 					"subtitle": "Bitte versuche es später erneut."
 				}
+			},
+			"clubs": {
+				"title": "Campus Life Vereine",
+				"description": "Folge deinen Lieblingsvereinen, um ihre Veranstaltungen mit Priorität zu sehen und sie in deinem Kalender anzuzeigen.",
+				"followInfo": "Priorisiere Events von gefolgten Vereinen",
+				"calendarInfo": "Events erscheinen in deiner Kalenderansicht",
+				"priorityInfo": "Events werden in der Liste hervorgehoben"
 			}
 		},
 		"careerService": {

--- a/src/localization/de/navigation.json
+++ b/src/localization/de/navigation.json
@@ -45,6 +45,7 @@
 		"roomReport": "Problem mit einem Raum melden",
 		"thiServices": "THI Services",
 		"clEvents": "Campus Life Veranstaltungen",
+		"clubs": "Campus Life Vereine",
 		"counselling": "Studienberatung"
 	},
 	"cards": {

--- a/src/localization/en/accessibility.json
+++ b/src/localization/en/accessibility.json
@@ -7,6 +7,7 @@
 		"settingsDashboard": "Dashboard Settings",
 		"libraryBarcode": "Library Number as Barcode",
 		"previous": "Previous",
+		"clubsFollow": "Follow Clubs",
 		"next": "Next"
 	}
 }

--- a/src/localization/en/common.json
+++ b/src/localization/en/common.json
@@ -326,6 +326,13 @@
 					"title": "No events found",
 					"subtitle": "Check back later."
 				}
+			},
+			"clubs": {
+				"title": "Campus Life Clubs",
+				"description": "Follow your favorite clubs to see their events with priority and view them in your calendar.",
+				"followInfo": "Prioritize events from followed clubs",
+				"calendarInfo": "Events appear in your calendar view",
+				"priorityInfo": "Events are highlighted in the list"
 			}
 		},
 		"careerService": {

--- a/src/localization/en/navigation.json
+++ b/src/localization/en/navigation.json
@@ -45,6 +45,7 @@
 		"roomReport": "Report Room Issue",
 		"thiServices": "THI Services",
 		"clEvents": "Campus Life Events",
+		"clubs": "Campus Life Clubs",
 		"counselling": "Student Counselling"
 	},
 	"cards": {

--- a/src/utils/events-utils.ts
+++ b/src/utils/events-utils.ts
@@ -3,6 +3,7 @@ import { getFragmentData } from '@/__generated__/gql'
 import {
 	type CampusLifeEventFieldsFragment,
 	CampusLifeEventFieldsFragmentDoc,
+	type Host,
 	type UniversitySportsFieldsFragment,
 	UniversitySportsFieldsFragmentDoc,
 	type WeekdayType
@@ -75,6 +76,11 @@ export async function loadUniversitySportsEvents(): Promise<GroupedSportsEvents>
 		.sort((a, b) => weekdays.indexOf(a.title) - weekdays.indexOf(b.title))
 
 	return sections
+}
+
+export async function loadCampusLifeClubs(): Promise<Host[]> {
+	const res = await NeulandAPI.getCampusLifeClubs()
+	return res.clClubs
 }
 
 interface SportsCategory {
@@ -221,7 +227,8 @@ export const QUERY_KEYS = {
 	CAREER_SERVICE_EVENTS: 'thi-services-career',
 	STUDENT_ADVISORY_EVENTS: 'thi-services-student-counselling',
 	UNIVERSITY_SPORTS: 'universitySports',
-	CAMPUS_LIFE_EVENTS: 'campusLifeEventsV5'
+	CAMPUS_LIFE_EVENTS: 'campusLifeEventsV5',
+	CAMPUS_LIFE_CLUBS: 'campusLifeClubs'
 } as const
 
 export const loadCareerServiceEvents = async () => {


### PR DESCRIPTION
## Summary
- create Zustand store for followed clubs
- add GraphQL query for Campus Life clubs and API method
- expose loader for clubs in events utils
- build a new `ClClubs` screen and header button
- register the screen in the root layout
- add navigation and accessibility strings

## Testing
- `bun run lint`
- `bun run codegen` *(fails: connect ENETUNREACH)*

------
