### PR TITLE
fix(map): resolve marker overlap issue

### DIFF
--- a/src/components/Map/MapScreen.tsx
+++ b/src/components/Map/MapScreen.tsx
@@ -731,7 +731,8 @@ const MapScreen = (): React.JSX.Element => {
 									iconImage: 'map-marker',
 									iconColor: theme.colors.primary,
 									iconSize: 0.17,
-									iconAnchor: 'bottom'
+									iconAnchor: 'bottom',
+									iconAllowOverlap: true
 								}}
 								layerIndex={104} // Ensure this layer is above others
 							/>


### PR DESCRIPTION
## Summary
- ensure room pin is visible even when zoomed out by allowing icon overlap

## Testing
- `npm run fmt`
- `npm run lint`

This pull request includes a small enhancement to the `MapScreen` component in `src/components/Map/MapScreen.tsx`. The change adds the `iconAllowOverlap` property to the map marker configuration, enabling icons to overlap if necessary.