### PR TITLE
Implement clipboard sharing on web

### DIFF
--- a/src/app/(screens)/events/career/[id].tsx
+++ b/src/app/(screens)/events/career/[id].tsx
@@ -31,6 +31,7 @@ import ShareHeaderButton from '@/components/Universal/ShareHeaderButton'
 import type { FormListSections } from '@/types/components'
 import { formatFriendlyDate } from '@/utils/date-utils'
 import { loadCareerServiceEvents, QUERY_KEYS } from '@/utils/events-utils'
+import { copyToClipboard } from '@/utils/ui-utils'
 
 export default function CareerServiceEvent(): React.JSX.Element {
 	const { id } = useLocalSearchParams<{ id: string }>()
@@ -108,12 +109,18 @@ export default function CareerServiceEvent(): React.JSX.Element {
 						onPress={async () => {
 							trackEvent('Share', { type: 'careerServiceEvent' })
 							const deepLinkUrl = `https://web.neuland.app/events/career/${id}`
+							const message = t('pages.event.shareCareerMessage', {
+								title: eventData?.title,
+								date: formatFriendlyDate(eventData?.date ?? ''),
+								link: deepLinkUrl
+							})
+							if (Platform.OS === 'web') {
+								await copyToClipboard(message)
+								return
+							}
+
 							await Share.share({
-								message: t('pages.event.shareCareerMessage', {
-									title: eventData?.title,
-									date: formatFriendlyDate(eventData?.date ?? ''),
-									link: deepLinkUrl
-								})
+								message
 							})
 						}}
 					/>

--- a/src/app/(screens)/events/cl/[id].tsx
+++ b/src/app/(screens)/events/cl/[id].tsx
@@ -33,6 +33,7 @@ import {
 } from '@/utils/date-utils'
 import { loadCampusLifeEvents, QUERY_KEYS } from '@/utils/events-utils'
 import { isValidRoom } from '@/utils/timetable-utils'
+import { copyToClipboard } from '@/utils/ui-utils'
 
 const URL_REGEX = /(https?:\/\/[^\s]+)/g
 
@@ -123,13 +124,19 @@ export default function ClEventDetail(): React.JSX.Element {
 								trackEvent('Share', {
 									type: 'clEvent'
 								})
+								const message = t('pages.event.shareMessage', {
+									title: eventData?.titles[i18n.language as LanguageKey],
+									organizer: eventData?.host.name,
+									date: dateRange,
+									link: `https://web.neuland.app/events/cl/${id}`
+								})
+								if (Platform.OS === 'web') {
+									await copyToClipboard(message)
+									return
+								}
+
 								await Share.share({
-									message: t('pages.event.shareMessage', {
-										title: eventData?.titles[i18n.language as LanguageKey],
-										organizer: eventData?.host.name,
-										date: dateRange,
-										link: `https://web.neuland.app/events/cl/${id}`
-									})
+									message
 								})
 							}}
 						/>

--- a/src/app/(screens)/events/counselling/[id].tsx
+++ b/src/app/(screens)/events/counselling/[id].tsx
@@ -31,6 +31,7 @@ import ShareHeaderButton from '@/components/Universal/ShareHeaderButton'
 import type { FormListSections } from '@/types/components'
 import { formatFriendlyDate } from '@/utils/date-utils'
 import { loadStudentCounsellingEvents, QUERY_KEYS } from '@/utils/events-utils'
+import { copyToClipboard } from '@/utils/ui-utils'
 
 export default function StudentCounsellingEventDetail(): React.JSX.Element {
 	const { t } = useTranslation('common')
@@ -110,12 +111,18 @@ export default function StudentCounsellingEventDetail(): React.JSX.Element {
 								type: 'studentCounsellingEvent'
 							})
 							const deepLinkUrl = `https://web.neuland.app/events/counselling/${id}`
+							const message = t('pages.event.shareCounsellingMessage', {
+								title: eventData?.title,
+								date: formatFriendlyDate(eventData?.date ?? ''),
+								link: deepLinkUrl
+							})
+							if (Platform.OS === 'web') {
+								await copyToClipboard(message)
+								return
+							}
+
 							await Share.share({
-								message: t('pages.event.shareCounsellingMessage', {
-									title: eventData?.title,
-									date: formatFriendlyDate(eventData?.date ?? ''),
-									link: deepLinkUrl
-								})
+								message
 							})
 						}}
 					/>

--- a/src/app/(screens)/events/sports/[id].tsx
+++ b/src/app/(screens)/events/sports/[id].tsx
@@ -32,6 +32,7 @@ import type { FormListSections } from '@/types/components'
 import type { MaterialIcon } from '@/types/material-icons'
 import { formatFriendlyTimeRange } from '@/utils/date-utils'
 import { loadUniversitySportsEvents, QUERY_KEYS } from '@/utils/events-utils'
+import { copyToClipboard } from '@/utils/ui-utils'
 
 export default function SportsEventDetail(): React.JSX.Element {
 	const { styles, theme } = useStyles(stylesheet)
@@ -88,20 +89,26 @@ export default function SportsEventDetail(): React.JSX.Element {
 							trackEvent('Share', {
 								type: 'sportsEvent'
 							})
+							const message = t('pages.event.shareSports', {
+								title: sportsEvent?.title[i18n.language as LanguageKey],
+								weekday: t(
+									`dates.weekdays.${
+										sportsEvent.weekday.toLowerCase() as Lowercase<WeekdayType>
+									}`
+								),
+								time: formatFriendlyTimeRange(
+									sportsEvent.startTime,
+									sportsEvent.endTime
+								),
+								link: `https://web.neuland.app/events/sports/${id}`
+							})
+							if (Platform.OS === 'web') {
+								await copyToClipboard(message)
+								return
+							}
+
 							await Share.share({
-								message: t('pages.event.shareSports', {
-									title: sportsEvent?.title[i18n.language as LanguageKey],
-									weekday: t(
-										`dates.weekdays.${
-											sportsEvent.weekday.toLowerCase() as Lowercase<WeekdayType>
-										}`
-									),
-									time: formatFriendlyTimeRange(
-										sportsEvent.startTime,
-										sportsEvent.endTime
-									),
-									link: `https://web.neuland.app/events/sports/${id}`
-								})
+								message
 							})
 						}}
 					/>

--- a/src/app/(screens)/food/[id].tsx
+++ b/src/app/(screens)/food/[id].tsx
@@ -50,6 +50,7 @@ import {
 	mealName,
 	shareMeal
 } from '@/utils/food-utils'
+import { copyToClipboard } from '@/utils/ui-utils'
 
 export default function FoodDetail(): React.JSX.Element {
 	const { id } = useLocalSearchParams<{ id: string }>()
@@ -470,13 +471,18 @@ export default function FoodDetail(): React.JSX.Element {
 						trackEvent('Share', {
 							type: 'mealVariant'
 						})
+						const message = t('details.share.message', {
+							meal: variant.name[i18n.language as LanguageKey],
+							price: formatPrice(variant.prices[userKind ?? USER_GUEST]),
+							location: restaurant,
+							id: variant?.id
+						})
+						if (Platform.OS === 'web') {
+							void copyToClipboard(message)
+							return
+						}
 						void Share.share({
-							message: t('details.share.message', {
-								meal: variant.name[i18n.language as LanguageKey],
-								price: formatPrice(variant.prices[userKind ?? USER_GUEST]),
-								location: restaurant,
-								id: variant?.id
-							})
+							message
 						})
 					}
 				})) ?? []

--- a/src/components/Map/BottomSheetDetailModal.tsx
+++ b/src/components/Map/BottomSheetDetailModal.tsx
@@ -6,7 +6,7 @@ import {
 import Color from 'color'
 import { router } from 'expo-router'
 import type React from 'react'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Platform, Pressable, Text, View } from 'react-native'
 import type { SharedValue } from 'react-native-reanimated'
@@ -83,6 +83,7 @@ export const BottomSheetDetailModal = ({
 	modalSection
 }: BottomSheetDetailModalProps): React.JSX.Element => {
 	const { styles } = useStyles(stylesheet)
+	const [copied, setCopied] = useState(false)
 	const IOS_SNAP_POINTS = ['36%', '55%', '80%']
 	const DEFAULT_SNAP_POINTS = ['30%', '40%', '70%']
 	return (
@@ -105,22 +106,26 @@ export const BottomSheetDetailModal = ({
 							{roomData.type === SEARCH_TYPES.ROOM && (
 								<Pressable
 									onPress={() => {
+										if (Platform.OS === 'web') {
+											setCopied(true)
+											setTimeout(() => setCopied(false), 1000)
+										}
 										handleShareModal(roomData.title)
 									}}
 									style={styles.roomDetailButton}
 								>
 									<PlatformIcon
 										ios={{
-											name: 'square.and.arrow.up',
+											name: copied ? 'checkmark' : 'square.and.arrow.up',
 											size: 14,
 											weight: 'bold'
 										}}
 										android={{
-											name: 'share',
+											name: copied ? 'check' : 'share',
 											size: 16
 										}}
 										web={{
-											name: 'Share',
+											name: copied ? 'Check' : 'Share',
 											size: 16
 										}}
 										style={styles.shareIcon(Platform.OS)}

--- a/src/components/Settings/SettingsMenu.tsx
+++ b/src/components/Settings/SettingsMenu.tsx
@@ -13,6 +13,7 @@ import { usePreferencesStore } from '@/hooks/usePreferencesStore'
 import type { FormListSections } from '@/types/components'
 import type { MaterialIcon } from '@/types/material-icons'
 import { storage } from '@/utils/storage'
+import { copyToClipboard } from '@/utils/ui-utils'
 
 export default function SettingsMenu(): React.JSX.Element {
 	const router = useRouter()
@@ -167,12 +168,19 @@ export default function SettingsMenu(): React.JSX.Element {
 					onPress: () => {
 						trackEvent('Share', { type: 'app' })
 
+						const message =
+							Platform.OS === 'ios'
+								? t('menu.formlist.legal.shareMessage')
+								: t('menu.formlist.legal.shareMessageAndroid')
+
+						if (Platform.OS === 'web') {
+							void copyToClipboard(message)
+							return
+						}
+
 						void Share.share({
 							url: 'https://neuland.app/get', // url option is only available on iOS
-							message:
-								Platform.OS === 'ios'
-									? t('menu.formlist.legal.shareMessage')
-									: t('menu.formlist.legal.shareMessageAndroid')
+							message
 						})
 					}
 				},

--- a/src/components/Universal/ShareHeaderButton.tsx
+++ b/src/components/Universal/ShareHeaderButton.tsx
@@ -1,5 +1,6 @@
 import { router } from 'expo-router'
 import type React from 'react'
+import { useState } from 'react'
 import { Platform, Pressable, View } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import { createStyleSheet, useStyles } from 'react-native-unistyles'
@@ -15,27 +16,32 @@ export default function ShareHeaderButton({
 	noShare = false
 }: ShareButtonProps): React.JSX.Element {
 	const { styles } = useStyles(stylesheet)
+	const [copied, setCopied] = useState(false)
 	return (
 		<View style={styles.shareRow}>
 			{!noShare && (
 				<Pressable
 					onPress={() => {
 						void onPress()
+						if (Platform.OS === 'web') {
+							setCopied(true)
+							setTimeout(() => setCopied(false), 1000)
+						}
 					}}
 					style={styles.shareButton}
 				>
 					<PlatformIcon
 						ios={{
-							name: 'square.and.arrow.up',
+							name: copied ? 'checkmark' : 'square.and.arrow.up',
 							size: 15,
 							weight: 'bold'
 						}}
 						android={{
-							name: 'share',
+							name: copied ? 'check' : 'share',
 							size: 20
 						}}
 						web={{
-							name: 'Share',
+							name: copied ? 'Check' : 'Share',
 							size: 20
 						}}
 						style={styles.icon}

--- a/src/utils/food-utils.ts
+++ b/src/utils/food-utils.ts
@@ -1,6 +1,6 @@
 import { trackEvent } from '@aptabase/react-native'
 import type { i18n, TFunction } from 'i18next'
-import { Share } from 'react-native'
+import { Platform, Share } from 'react-native'
 import { getFragmentData } from '@/__generated__/gql'
 import { FoodFieldsFragmentDoc } from '@/__generated__/gql/graphql'
 import NeulandAPI from '@/api/neuland-api'
@@ -11,8 +11,8 @@ import type { FoodLanguage } from '@/hooks/useFoodFilterStore'
 import type { LanguageKey } from '@/localization/i18n'
 import type { Food, Meal, Name } from '@/types/neuland-api'
 import type { Labels, Prices } from '@/types/utils'
-
 import { formatISODate } from './date-utils'
+import { copyToClipboard } from './ui-utils'
 
 export const humanLocations = {
 	IngolstadtMensa: 'Mensa Ingolstadt',
@@ -194,17 +194,24 @@ export function shareMeal(
 	trackEvent('Share', {
 		type: 'meal'
 	})
-	void Share.share({
-		message: i18n.t('details.share.message', {
-			ns: 'food',
-			meal: meal?.name[i18n.language as LanguageKey],
-			price: formatPrice(meal.prices[userKind ?? USER_GUEST]),
-			location:
-				meal?.restaurant != null
-					? humanLocations[meal.restaurant as keyof typeof humanLocations]
-					: i18n.t('misc.unknown', { ns: 'common' }),
+	const message = i18n.t('details.share.message', {
+		ns: 'food',
+		meal: meal?.name[i18n.language as LanguageKey],
+		price: formatPrice(meal.prices[userKind ?? USER_GUEST]),
+		location:
+			meal?.restaurant != null
+				? humanLocations[meal.restaurant as keyof typeof humanLocations]
+				: i18n.t('misc.unknown', { ns: 'common' }),
 
-			id: meal?.id
-		})
+		id: meal?.id
+	})
+
+	if (Platform.OS === 'web') {
+		void copyToClipboard(message)
+		return
+	}
+
+	void Share.share({
+		message
 	})
 }

--- a/src/utils/map-utils.ts
+++ b/src/utils/map-utils.ts
@@ -5,8 +5,8 @@ import { SEARCH_TYPES } from '@/types/map'
 import type { MaterialIcon } from '@/types/material-icons'
 import type { Rooms, TypeStunde } from '@/types/thi-api'
 import type { AvailableRoom } from '@/types/utils'
-
 import { formatISODate } from './date-utils'
+import { copyToClipboard } from './ui-utils'
 
 const IGNORE_GAPS = 15
 
@@ -345,6 +345,11 @@ export const handleShareModal = (room: string): void => {
 	trackEvent('Share', {
 		type: 'room'
 	})
+	if (Platform.OS === 'web') {
+		void copyToClipboard(payload)
+		return
+	}
+
 	void Share.share(
 		Platform.OS === 'android' ? { message: payload } : { url: payload }
 	)


### PR DESCRIPTION
## Summary
- copy map room links to clipboard on web
- copy meal sharing text on web
- update events and settings share logic for clipboard on web
- animate share header icons with a checkmark
- show checkmark when sharing map room links

## Testing
- `bun run fmt`
- `bun run lint`

------
https://chatgpt.com/codex/tasks/task_b_685805bfbfbc8326b6bd5184f89e845c