### PR TITLE
Add lecturers to map detail sheets

### DIFF
--- a/src/components/Map/MapScreen.web.tsx
+++ b/src/components/Map/MapScreen.web.tsx
@@ -49,13 +49,16 @@ import MapBottomSheet from '@/components/Map/BottomSheetMap'
 import FloorPicker from '@/components/Map/FloorPicker'
 import { MapContext } from '@/contexts/map'
 import { USER_GUEST } from '@/data/constants'
+import useRouteParamsStore from '@/hooks/useRouteParamsStore'
 import { type FeatureProperties, Gebaeude } from '@/types/asset-api'
 import {
 	type ClickedMapElement,
 	type RoomData,
 	SEARCH_TYPES
 } from '@/types/map'
+import type { NormalizedLecturer } from '@/types/utils'
 import { formatISODate, formatISOTime } from '@/utils/date-utils'
+import { normalizeLecturers } from '@/utils/lecturers-utils'
 import {
 	filterAvailableRooms,
 	filterEtage,
@@ -190,6 +193,18 @@ const MapScreen = (): React.JSX.Element => {
 			}
 			return failureCount < 2
 		},
+		enabled: userKind !== USER_GUEST
+	})
+
+	const { data: lecturers } = useQuery({
+		queryKey: ['allLecturers'],
+		queryFn: async () => {
+			const rawData = await API.getLecturers('0', 'z')
+			const data = normalizeLecturers(rawData)
+			return data
+		},
+		staleTime: 1000 * 60 * 30, // 30 minutes
+		gcTime: 1000 * 60 * 60 * 24 * 7, // 7 days
 		enabled: userKind !== USER_GUEST
 	})
 
@@ -497,6 +512,52 @@ const MapScreen = (): React.JSX.Element => {
 				} as RoomData
 		}
 	}, [clickedElement])
+
+	const setSelectedLecturer = useRouteParamsStore(
+		(state) => state.setSelectedLecturer
+	)
+
+	const handleOpenLecturer = useCallback(
+		(lecturer: NormalizedLecturer) => {
+			setSelectedLecturer(lecturer)
+			router.navigate('/lecturer')
+		},
+		[setSelectedLecturer]
+	)
+
+	const lecturerSection = useMemo(() => {
+		if (clickedElement?.type !== SEARCH_TYPES.ROOM || lecturers == null) {
+			return []
+		}
+
+		const filtered = lecturers.filter(
+			(l) => l.room_short === clickedElement.data
+		)
+
+		if (filtered.length === 0) {
+			return []
+		}
+
+		return [
+			{
+				header: t('pages.map.details.room.lecturers', { ns: 'common' }),
+				items: filtered.map((l) => ({
+					title: `${[l.titel, l.vorname, l.name].join(' ').trim()}`,
+					onPress: () => handleOpenLecturer(l)
+				}))
+			}
+		]
+	}, [clickedElement, lecturers, handleOpenLecturer])
+
+	const baseSections = useMemo(
+		() => modalSection(roomData, locations, userKind === USER_GUEST),
+		[roomData, locations, userKind]
+	)
+
+	const allSections = useMemo(
+		() => [...lecturerSection, ...baseSections],
+		[baseSections, lecturerSection]
+	)
 
 	function setView(clickedElement: ClickedMapElement | null = null): void {
 		if (!mapRef.current || !clickedElement?.center) return
@@ -856,11 +917,7 @@ const MapScreen = (): React.JSX.Element => {
 				handleSheetChangesModal={handleSheetChangesModal}
 				currentPositionModal={currentPositionModal}
 				roomData={roomData}
-				modalSection={modalSection(
-					roomData,
-					locations,
-					userKind === USER_GUEST
-				)}
+				modalSection={allSections}
 			/>
 		</View>
 	)

--- a/src/localization/de/common.json
+++ b/src/localization/de/common.json
@@ -237,6 +237,7 @@
 					"history": "Zuletzt gesucht",
 					"signIn": "Melden dich an, um verfügbare Räume anzuzeigen",
 					"equipment": "Ausstattung",
+					"lecturers": "Dozenten",
 					"report": "Fehler melden",
 					"reportMail": "mailto:feedback@neuland.app?subject=Raum%20Fehler%20melden&body=Raum%3A%0D%0AProblem%3A%0D%0AVorschlag%3A"
 				},

--- a/src/localization/en/common.json
+++ b/src/localization/en/common.json
@@ -230,6 +230,7 @@
 					"floor": "Floor",
 					"type": "Type",
 					"equipment": "Equipment",
+					"lecturers": "Lecturers",
 					"available": "Available",
 					"notAvailable": "Not available",
 					"availableRooms": "Available rooms",


### PR DESCRIPTION
## Summary
- fetch lecturers in MapScreen
- include lecturers assigned to a room in the detail sheet
- link to lecturer detail page when tapping a name
- add translations for this feature
- place the lecturer section above base sections
- support lecturer details on web map

## Testing
- `bun lint`


------
https://chatgpt.com/codex/tasks/task_b_68580fcb17b88326b2571011d93026db