### PR TITLE
refactor: remove leftover localization for deprecated features

### DIFF
--- a/src/localization/de/common.json
+++ b/src/localization/de/common.json
@@ -363,12 +363,5 @@
 			}
 		}
 	},
-	"notification": {
-		"permission": {
-			"title": "Benachrichtigungen",
-			"description": "Öffne die System-Einstellungen, um Benachrichtigungen zu aktivieren.",
-			"button": "Einstellungen"
-		}
-	},
 	"submit": "Absenden"
 }

--- a/src/localization/de/navigation.json
+++ b/src/localization/de/navigation.json
@@ -14,7 +14,6 @@
 		"allergens": "Allergene",
 		"details": "Details",
 		"theme": "Design",
-		"accent": "Akzentfarbe",
 		"profile": "Profil",
 		"about": "Über",
 		"version": "Versionsdetails",
@@ -33,7 +32,6 @@
 		"news": "THI Neuigkeiten",
 		"library": "Bibliothek",
 		"libraryCode": "Bibliotheksnummer",
-		"notifications": "Benachrichtigungen",
 		"licenses": {
 			"title": "Lizenzen",
 			"search": "Suche Lizenzen"

--- a/src/localization/de/settings.json
+++ b/src/localization/de/settings.json
@@ -29,7 +29,6 @@
 			},
 			"appearance": {
 				"title": "Darstellung",
-				"accent": "Akzentfarbe",
 				"theme": "Design"
 			},
 			"language": {
@@ -140,21 +139,6 @@
 		}
 	},
 	"theme": {
-		"accent": {
-			"title": "Akzentfarbe"
-		},
-		"colors": {
-			"teal": "Türkis",
-			"blue": "Blau",
-			"contrast": "Kontrast",
-			"pink": "Pink",
-			"brown": "Braun",
-			"purple": "Lila",
-			"yellow": "Gelb",
-			"orange": "Orange",
-			"green": "Neuland"
-		},
-		"footer": "Das ändert die Farbe der Symbole und Schaltflächen in der App.",
 		"themes": {
 			"title": "Design",
 			"default": "Automatisch",

--- a/src/localization/en/common.json
+++ b/src/localization/en/common.json
@@ -363,12 +363,5 @@
 			}
 		}
 	},
-	"notification": {
-		"permission": {
-			"title": "Notifications",
-			"description": "Open the system settings to enable notifications.",
-			"button": "Settings"
-		}
-	},
 	"submit": "Submit"
 }

--- a/src/localization/en/navigation.json
+++ b/src/localization/en/navigation.json
@@ -13,7 +13,6 @@
 		"allergens": "Allergens",
 		"details": "Details",
 		"theme": "Design",
-		"accent": "Accent Color",
 		"profile": "Profile",
 		"about": "About",
 		"version": "Version Details",
@@ -33,7 +32,6 @@
 		"library": "Library",
 		"legal": "Legal",
 		"libraryCode": "Library Number",
-		"notifications": "Notifications",
 		"licenses": {
 			"title": "Licenses",
 			"search": "Search licenses"

--- a/src/localization/en/settings.json
+++ b/src/localization/en/settings.json
@@ -29,7 +29,6 @@
 			},
 			"appearance": {
 				"title": "Appearance",
-				"accent": "Accent Color",
 				"theme": "Design"
 			},
 			"language": {
@@ -161,21 +160,6 @@
 		}
 	},
 	"theme": {
-		"accent": {
-			"title": "Accent color"
-		},
-		"colors": {
-			"teal": "Teal",
-			"blue": "Blue",
-			"contrast": "Contrast",
-			"pink": "Pink",
-			"brown": "Brown",
-			"purple": "Purple",
-			"yellow": "Yellow",
-			"orange": "Orange",
-			"green": "Neuland"
-		},
-		"footer": "This changes the color of the icons and buttons in the app.",
 		"themes": {
 			"title": "Theme",
 			"default": "Automatic",


### PR DESCRIPTION
## Summary
- clean up unused accent color strings
- drop notification permission messages

## Testing
- `npm run lint`
