### PR TITLE
Update locked app icon behavior

### DIFF
--- a/src/localization/de/settings.json
+++ b/src/localization/de/settings.json
@@ -219,7 +219,11 @@
 			"rainbow": "Regenbogen",
 			"exclusive": "Exklusiv"
 		},
-		"exclusive": "Besuche unsere Veranstaltungen und finde Easter-Eggs, um exklusive App-Icons freizuschalten."
+		"exclusive": "Finde Easter-Eggs, um exklusive App-Icons freizuschalten.",
+		"status": {
+			"locked": "Gesperrt",
+			"unlocked": "Freigeschaltet"
+		}
 	},
 	"version": {
 		"formlist": {

--- a/src/localization/en/settings.json
+++ b/src/localization/en/settings.json
@@ -240,6 +240,10 @@
 			"rainbow": "Rainbow",
 			"exclusive": "Exclusive"
 		},
-		"exclusive": "Attend to our events and find easter eggs to unlock exclusive app icons."
+		"exclusive": "Find easter eggs to unlock exclusive app icons.",
+		"status": {
+			"locked": "Locked",
+			"unlocked": "Unlocked"
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- display checkmark only when icon is active
- show `Locked` label only for locked exclusive icons
- dim locked icon previews more
- tweak exclusive icon hint to only mention easter eggs

## Testing
- `npm run fmt`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685816c1a1248326955b07e0f18d6f08