### PR TITLE
feat(calendar): add month label to week header

### DIFF
--- a/src/components/Timetable/TimetableWeek.tsx
+++ b/src/components/Timetable/TimetableWeek.tsx
@@ -37,6 +37,7 @@ import LoadingIndicator from '../Universal/LoadingIndicator'
 import { HeaderRight } from './HeaderButtons'
 import EventComponent from './WeekEventComponent'
 import WeekHeaderEvent from './WeekHeaderEvent'
+import WeekLeftArea from './WeekLeftArea'
 
 const timetableNumberDaysMap = {
 	[TimetableMode.List]: 1,
@@ -346,13 +347,16 @@ export default function TimetableWeek({
 				onPressDayNumber={(date) => {
 					calendarRef.current?.goToDate({ date })
 				}}
-				showWeekNumber
+				showWeekNumber={false}
 				rightEdgeSpacing={3}
 				overlapEventsSpacing={1}
 				minTimeIntervalHeight={55}
 				scrollToNow={false}
 			>
-				<CalendarHeader renderEvent={renderHeaderEvent} />
+				<CalendarHeader
+					LeftAreaComponent={<WeekLeftArea />}
+					renderEvent={renderHeaderEvent}
+				/>
 				<CalendarBody renderEvent={renderEvent} hourFormat="HH:mm" />
 			</CalendarContainer>
 		</View>

--- a/src/components/Timetable/WeekLeftArea.tsx
+++ b/src/components/Timetable/WeekLeftArea.tsx
@@ -5,6 +5,7 @@ import {
 	useTheme,
 	useTimezone
 } from '@howljs/calendar-kit'
+// @ts-expect-error no types since it is an internal dependency
 import { DateTime } from 'luxon'
 import type React from 'react'
 import { useCallback, useState } from 'react'
@@ -71,14 +72,15 @@ const stylesheet = createStyleSheet((theme) => ({
 		alignItems: 'center'
 	},
 	weekText: {
-		fontSize: 12,
+		fontSize: 11,
 		textAlign: 'center',
 		color: theme.colors.text
 	},
 	monthText: {
-		fontSize: 10,
+		fontSize: 12,
 		textAlign: 'center',
-		lineHeight: 12,
+		lineHeight: 13,
+		fontWeight: 500,
 		color: theme.colors.text
 	}
 }))

--- a/src/components/Timetable/WeekLeftArea.tsx
+++ b/src/components/Timetable/WeekLeftArea.tsx
@@ -1,0 +1,84 @@
+import {
+	getWeekNumberOfYear,
+	parseDateTime,
+	useCalendar,
+	useTheme,
+	useTimezone
+} from '@howljs/calendar-kit'
+import { DateTime } from 'luxon'
+import type React from 'react'
+import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Text, View } from 'react-native'
+import { runOnJS, useAnimatedReaction } from 'react-native-reanimated'
+import { createStyleSheet, useStyles } from 'react-native-unistyles'
+
+export default function WeekLeftArea(): React.JSX.Element {
+	const { styles } = useStyles(stylesheet)
+	const { visibleDateUnixAnim } = useCalendar()
+	const { timeZone } = useTimezone()
+	const theme = useTheme((state) => ({
+		weekNumberBackgroundColor: state.colors.surface,
+		weekNumber: state.weekNumber,
+		weekNumberContainer: state.weekNumberContainer
+	}))
+	const { t } = useTranslation('timetable')
+	const [week, setWeek] = useState<string | number>('')
+	const [month, setMonth] = useState('')
+
+	const updateValues = useCallback(
+		(unix: number) => {
+			const date = parseDateTime(unix).setZone(timeZone)
+			setWeek(getWeekNumberOfYear(unix, timeZone))
+			setMonth(date.setLocale(DateTime.local().locale).toFormat('MMM'))
+		},
+		[timeZone]
+	)
+
+	useAnimatedReaction(
+		() => visibleDateUnixAnim.value,
+		(value, prev) => {
+			if (value !== prev) {
+				runOnJS(updateValues)(value)
+			}
+		},
+		[]
+	)
+
+	return (
+		<View
+			style={[
+				styles.container,
+				{ backgroundColor: theme.weekNumberBackgroundColor },
+				theme.weekNumberContainer
+			]}
+		>
+			<Text style={[styles.weekText, theme.weekNumber]}>
+				{`${t('weekNumberPrefix')}${week}`}
+			</Text>
+			<Text style={[styles.monthText, theme.weekNumber]}>{month}</Text>
+		</View>
+	)
+}
+
+const stylesheet = createStyleSheet((theme) => ({
+	container: {
+		backgroundColor: '#DADADA',
+		marginHorizontal: 8,
+		borderRadius: 4,
+		marginTop: 8,
+		paddingVertical: 2,
+		alignItems: 'center'
+	},
+	weekText: {
+		fontSize: 12,
+		textAlign: 'center',
+		color: theme.colors.text
+	},
+	monthText: {
+		fontSize: 10,
+		textAlign: 'center',
+		lineHeight: 12,
+		color: theme.colors.text
+	}
+}))

--- a/src/localization/de/timetable.json
+++ b/src/localization/de/timetable.json
@@ -61,6 +61,7 @@
 		"weekDayShort": ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
 		"more": "mehr"
 	},
+	"weekNumberPrefix": "KW",
 	"weekdays": {
 		"short": ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"],
 		"single": ["M", "D", "M", "D", "F", "S", "S"],

--- a/src/localization/en/timetable.json
+++ b/src/localization/en/timetable.json
@@ -61,6 +61,7 @@
 		"weekDayShort": ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
 		"more": "more"
 	},
+	"weekNumberPrefix": "CW",
 	"weekdays": {
 		"short": ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
 		"single": ["M", "T", "W", "T", "F", "S", "S"],


### PR DESCRIPTION
## Summary
- add `weekNumberPrefix` translations for English and German
- prefix week number with localized label in `WeekLeftArea`
- remove whitespace between prefix and week number

## Testing
- `npx biome format --write src/components/Timetable/WeekLeftArea.tsx`
- `npx biome lint src/components/Timetable/WeekLeftArea.tsx`
- `npm run lint`


<img width="209" alt="image" src="https://github.com/user-attachments/assets/c89ff580-8a2a-4a30-8810-c99e4b68ba26" />