### PR TITLE
Fix overlay z-index for map markers

### DIFF
--- a/src/components/Map/MapScreen.tsx
+++ b/src/components/Map/MapScreen.tsx
@@ -797,7 +797,8 @@ const MapScreen = (): React.JSX.Element => {
 									iconAnchor: 'bottom',
 									iconAllowOverlap: true
 								}}
-								layerIndex={104} // Ensure this layer is above others
+								// place marker above all overlays
+								layerIndex={106}
 							/>
 						</ShapeSource>
 					)}

--- a/src/components/Map/MapScreen.tsx
+++ b/src/components/Map/MapScreen.tsx
@@ -797,8 +797,7 @@ const MapScreen = (): React.JSX.Element => {
 									iconAnchor: 'bottom',
 									iconAllowOverlap: true
 								}}
-								// place marker above all overlays
-								layerIndex={106}
+								layerIndex={110}
 							/>
 						</ShapeSource>
 					)}


### PR DESCRIPTION
## Summary
- ensure clicked room marker is rendered above map overlays

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685c9e7864e483269b97603f1b0a22d7