### PR TITLE
fix(dashboard): card context menu background 

### DIFF
--- a/src/components/Cards/card-context-menu.tsx
+++ b/src/components/Cards/card-context-menu.tsx
@@ -30,6 +30,7 @@ export function CardContextMenu({
 		<ContextMenu
 			previewBackgroundColor="transparent"
 			borderRadius={28}
+			disableShadow={true}
 			actions={[
 				{
 					title: t('contextMenu.settings'),


### PR DESCRIPTION
## 📋 Description

Fix the overlapping background on cards when opening the context menu on iOS.

**Before:**

https://github.com/user-attachments/assets/120cd396-6064-425d-a9c6-be2fcf8f61e9

**After:**


https://github.com/user-attachments/assets/2b952570-93fd-4d5b-8a8a-20bd0455efb1








<!-- Please describe the changes you’ve made and the motivation behind them. -->

## ✅ Checklist

- [x] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web

- [ ] I’ve added or updated documentation (if needed)
- [ ] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

<!-- Anything else reviewers should be aware of? -->
