### PR TITLE
fix: handle empty announcement URL

### DIFF
--- a/src/components/Cards/announcement-card.tsx
+++ b/src/components/Cards/announcement-card.tsx
@@ -176,7 +176,7 @@ const AnnouncementCard: React.FC<AnnouncementCardProps> = ({ data }) => {
 						/>
 					)}
 				</View>
-				{url && (
+				{url != null && url !== '' && (
 					<Text style={styles.footer}>{t('cards.announcements.readMore')}</Text>
 				)}
 			</View>


### PR DESCRIPTION
## 📋 Description

<!-- Please describe the changes you’ve made and the motivation behind them. -->
Handle empty announcement URL instead of just checking for null.
## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web

- [ ] I’ve added or updated documentation (if needed)
- [ ] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

<!-- Anything else reviewers should be aware of? -->
