### PR TITLE
feat: rework logic for showing upcoming events in the calendar card

### DIFF
--- a/src/components/Cards/calendar-card.tsx
+++ b/src/components/Cards/calendar-card.tsx
@@ -10,32 +10,27 @@ import { USER_GUEST, USER_STUDENT } from '@/data/constants'
 import { useFlowStore } from '@/hooks/useFlowStore'
 import useRouteParamsStore from '@/hooks/useRouteParamsStore'
 import type { LanguageKey } from '@/localization/i18n'
-import type { Calendar } from '@/types/data'
-import type { Exam } from '@/types/utils'
-import { calendar, loadExamList } from '@/utils/calendar-utils'
+import {
+	type CalendarCardEvent,
+	type CalendarCardExam,
+	calendar,
+	loadExamList,
+	selectCalendarCardEvents
+} from '@/utils/calendar-utils'
 import EventItem from '../Universal/event-item'
 import BaseCard from './base-card'
 
 const CalendarCard = (): React.JSX.Element => {
-	type Combined = Calendar | CardExams
 	const router = useRouter()
 	const time = new Date()
 	const { i18n, t } = useTranslation(['navigation', 'common'])
-	const [mixedCalendar, setMixedCalendar] = useState<Combined[]>([])
+	const [mixedCalendar, setMixedCalendar] = useState<CalendarCardEvent[]>([])
 	const isOnboarded = useFlowStore((state) => state.isOnboarded)
 	const setExam = useRouteParamsStore((state) => state.setSelectedExam)
 	const { userKind = USER_GUEST } = React.use(UserKindContext)
 
-	interface CardExams {
-		name: string
-		begin: Date
-		end?: Date
-		isExam?: boolean
-		examData?: Exam
-	}
-
-	async function loadExams(): Promise<CardExams[]> {
-		let exams: CardExams[] = []
+	async function loadExams(): Promise<CalendarCardExam[]> {
+		let exams: CalendarCardExam[] = []
 		try {
 			exams = (await loadExamList()).map((x) => ({
 				name: t('navigation:cards.calendar.exam', { name: x.name }),
@@ -73,46 +68,8 @@ const CalendarCard = (): React.JSX.Element => {
 	})
 
 	useEffect(() => {
-		const nowMs = time.getTime()
-		// Next relevant moment per event: begin if the event has not started yet, end if it's already ongoing
-		const effectiveMs = (item: { begin: Date; end?: Date }) =>
-			item.begin.getTime() > nowMs
-				? item.begin.getTime()
-				: (item.end ?? item.begin).getTime()
-
-		const combined = [
-			...calendar.map((item) => ({ ...item, isExam: false })),
-			...(exams ?? [])
-		]
-			.map((item) => ({ ...item, begin: new Date(item.begin) }))
-			.filter((x) => x.begin > time || (x.end ?? time) > time)
-			.sort((a, b) => {
-				// Sort by the next relevant moment
-				// For single-day events, this is the date,
-				// for multi-day events, this is the start or end date, depending on
-				// whether the event is has already started or not.
-				const dateComparison = effectiveMs(a) - effectiveMs(b)
-				if (dateComparison !== 0) {
-					return dateComparison
-				}
-
-				// Same effective time: prioritize exams over calendar events
-				if (a.isExam && !b.isExam) return -1
-				if (!a.isExam && b.isExam) return 1
-
-				return 0
-			}) as Combined[]
-
-		// Always pin the next upcoming exam to the first row, then fill the
-		// remaining slot with the chronologically next non-pinned event.
-		const nextExam = combined.find((item) => 'isExam' in item && item.isExam)
-		if (nextExam) {
-			const rest = combined.filter((item) => item !== nextExam)
-			setMixedCalendar([nextExam, ...rest].slice(0, 2))
-		} else {
-			setMixedCalendar(combined.slice(0, 2))
-		}
-	}, [calendar, exams])
+		setMixedCalendar(selectCalendarCardEvents(calendar, exams ?? [], time))
+	}, [exams])
 
 	const { theme, styles } = useStyles(stylesheet)
 

--- a/src/components/Cards/calendar-card.tsx
+++ b/src/components/Cards/calendar-card.tsx
@@ -103,8 +103,15 @@ const CalendarCard = (): React.JSX.Element => {
 				return 0
 			}) as Combined[]
 
-		// Show the two chronologically next events
-		setMixedCalendar(combined.slice(0, 2))
+		// Always pin the next upcoming exam to the first row, then fill the
+		// remaining slot with the chronologically next non-pinned event.
+		const nextExam = combined.find((item) => 'isExam' in item && item.isExam)
+		if (nextExam) {
+			const rest = combined.filter((item) => item !== nextExam)
+			setMixedCalendar([nextExam, ...rest].slice(0, 2))
+		} else {
+			setMixedCalendar(combined.slice(0, 2))
+		}
 	}, [calendar, exams])
 
 	const { theme, styles } = useStyles(stylesheet)

--- a/src/components/Cards/calendar-card.tsx
+++ b/src/components/Cards/calendar-card.tsx
@@ -12,8 +12,9 @@ import useRouteParamsStore from '@/hooks/useRouteParamsStore'
 import type { LanguageKey } from '@/localization/i18n'
 import {
 	type CalendarCardEvent,
-	type CalendarCardExam,
+	type CalendarCardExamInput,
 	calendar,
+	isCalendarCardExam,
 	loadExamList,
 	selectCalendarCardEvents
 } from '@/utils/calendar-utils'
@@ -29,13 +30,12 @@ const CalendarCard = (): React.JSX.Element => {
 	const setExam = useRouteParamsStore((state) => state.setSelectedExam)
 	const { userKind = USER_GUEST } = React.use(UserKindContext)
 
-	async function loadExams(): Promise<CalendarCardExam[]> {
-		let exams: CalendarCardExam[] = []
+	async function loadExams(): Promise<CalendarCardExamInput[]> {
+		let exams: CalendarCardExamInput[] = []
 		try {
 			exams = (await loadExamList()).map((x) => ({
 				name: t('navigation:cards.calendar.exam', { name: x.name }),
 				begin: new Date(x.date),
-				isExam: true,
 				examData: x
 			}))
 		} catch (e) {
@@ -92,22 +92,18 @@ const CalendarCard = (): React.JSX.Element => {
 					<Pressable
 						key={index}
 						onPress={
-							'isExam' in event && 'examData' in event
+							isCalendarCardExam(event)
 								? () => {
-										if (event.examData) {
-											setExam(event.examData)
+										setExam(event.examData)
 
-											router.navigate({
-												pathname: '/calendar',
-												params: {
-													openExam: 'true'
-												}
-											})
-										}
+										router.navigate({
+											pathname: '/calendar',
+											params: {
+												openExam: 'true'
+											}
+										})
 									}
-								: 'id' in event
-									? () => router.navigate(`/calendar?event=${event.id}`)
-									: undefined
+								: () => router.navigate(`/calendar?event=${event.id}`)
 						}
 					>
 						<EventItem

--- a/src/components/Cards/calendar-card.tsx
+++ b/src/components/Cards/calendar-card.tsx
@@ -73,6 +73,13 @@ const CalendarCard = (): React.JSX.Element => {
 	})
 
 	useEffect(() => {
+		const nowMs = time.getTime()
+		// Next relevant moment per event: begin if the event has not started yet, end if it's already ongoing
+		const effectiveMs = (item: { begin: Date; end?: Date }) =>
+			item.begin.getTime() > nowMs
+				? item.begin.getTime()
+				: (item.end ?? item.begin).getTime()
+
 		const combined = [
 			...calendar.map((item) => ({ ...item, isExam: false })),
 			...(exams ?? [])
@@ -80,28 +87,23 @@ const CalendarCard = (): React.JSX.Element => {
 			.map((item) => ({ ...item, begin: new Date(item.begin) }))
 			.filter((x) => x.begin > time || (x.end ?? time) > time)
 			.sort((a, b) => {
-				// First, prioritize single-day events and exams over multi-day events
-				const aIsSingleDay = !a.end || a.isExam
-				const bIsSingleDay = !b.end || b.isExam
-
-				// If one is single-day and the other is multi-day, prioritize single-day
-				if (aIsSingleDay && !bIsSingleDay) return -1
-				if (!aIsSingleDay && bIsSingleDay) return 1
-
-				// If both are the same type (both single-day or both multi-day), sort by start time
-				const dateComparison = a.begin.getTime() - b.begin.getTime()
+				// Sort by the next relevant moment
+				// For single-day events, this is the date,
+				// for multi-day events, this is the start or end date, depending on
+				// whether the event is has already started or not.
+				const dateComparison = effectiveMs(a) - effectiveMs(b)
 				if (dateComparison !== 0) {
 					return dateComparison
 				}
 
-				// If start times are the same, prioritize exams over regular events
+				// Same effective time: prioritize exams over calendar events
 				if (a.isExam && !b.isExam) return -1
 				if (!a.isExam && b.isExam) return 1
 
-				// If both are the same type and have the same start time, maintain original order
 				return 0
 			}) as Combined[]
 
+		// Show the two chronologically next events
 		setMixedCalendar(combined.slice(0, 2))
 	}, [calendar, exams])
 

--- a/src/utils/calendar-utils.ts
+++ b/src/utils/calendar-utils.ts
@@ -128,3 +128,74 @@ export function getNextReRegistrationEvent(
 		.filter((event) => event.begin > referenceDate)
 		.sort((a, b) => a.begin.getTime() - b.begin.getTime())[0]
 }
+
+export interface CalendarCardExam {
+	name: string
+	begin: Date
+	end?: Date
+	isExam?: boolean
+	examData?: Exam
+}
+
+export type CalendarCardEvent = Calendar | CalendarCardExam
+
+/**
+ * Returns the next relevant moment of an event as a timestamp.
+ *
+ * For events that have not started yet this is the begin date, for events
+ * that are already ongoing it is the end date (the next deadline). Single-day
+ * events without an end always use their begin date.
+ */
+export function getCalendarCardEffectiveTime(
+	item: { begin: Date; end?: Date },
+	now: Date
+): number {
+	return item.begin.getTime() > now.getTime()
+		? item.begin.getTime()
+		: (item.end ?? item.begin).getTime()
+}
+
+/**
+ * Selects the (up to) two events shown on the calendar dashboard card.
+ *
+ * Events are ranked by their next relevant moment (see
+ * {@link getCalendarCardEffectiveTime}). The next upcoming exam is always
+ * pinned to the first row, regardless of chronological order; the remaining
+ * slot is filled with the next event by effective time. When no exam is
+ * available, the two chronologically next events are returned.
+ */
+export function selectCalendarCardEvents(
+	calendarEvents: Calendar[],
+	exams: CalendarCardExam[],
+	now: Date = new Date()
+): CalendarCardEvent[] {
+	const combined = [
+		...calendarEvents.map((item) => ({ ...item, isExam: false })),
+		...exams
+	]
+		.map((item) => ({ ...item, begin: new Date(item.begin) }))
+		.filter((x) => x.begin > now || (x.end ?? now) > now)
+		.sort((a, b) => {
+			const dateComparison =
+				getCalendarCardEffectiveTime(a, now) -
+				getCalendarCardEffectiveTime(b, now)
+			if (dateComparison !== 0) {
+				return dateComparison
+			}
+
+			// Same effective time: prioritize exams over calendar events
+			if (a.isExam && !b.isExam) return -1
+			if (!a.isExam && b.isExam) return 1
+
+			return 0
+		}) as CalendarCardEvent[]
+
+	// Always pin the next upcoming exam to the first row, then fill the
+	// remaining slot with the chronologically next non-pinned event.
+	const nextExam = combined.find((item) => 'isExam' in item && item.isExam)
+	if (nextExam) {
+		const rest = combined.filter((item) => item !== nextExam)
+		return [nextExam, ...rest].slice(0, 2)
+	}
+	return combined.slice(0, 2)
+}

--- a/src/utils/calendar-utils.ts
+++ b/src/utils/calendar-utils.ts
@@ -129,15 +129,32 @@ export function getNextReRegistrationEvent(
 		.sort((a, b) => a.begin.getTime() - b.begin.getTime())[0]
 }
 
-export interface CalendarCardExam {
+export interface CalendarCardExamInput {
 	name: string
 	begin: Date
 	end?: Date
-	isExam?: boolean
-	examData?: Exam
+	examData: Exam
 }
 
-export type CalendarCardEvent = Calendar | CalendarCardExam
+export type CalendarCardCalendarEvent = Calendar & { isExam: false }
+
+export interface CalendarCardExamEvent {
+	isExam: true
+	name: string
+	begin: Date
+	end?: Date
+	examData: Exam
+}
+
+export type CalendarCardEvent =
+	| CalendarCardCalendarEvent
+	| CalendarCardExamEvent
+
+export function isCalendarCardExam(
+	event: CalendarCardEvent
+): event is CalendarCardExamEvent {
+	return event.isExam === true
+}
 
 /**
  * Returns the next relevant moment of an event as a timestamp.
@@ -166,14 +183,27 @@ export function getCalendarCardEffectiveTime(
  */
 export function selectCalendarCardEvents(
 	calendarEvents: Calendar[],
-	exams: CalendarCardExam[],
+	exams: CalendarCardExamInput[],
 	now: Date = new Date()
 ): CalendarCardEvent[] {
-	const combined = [
-		...calendarEvents.map((item) => ({ ...item, isExam: false })),
-		...exams
+	const combined: CalendarCardEvent[] = [
+		...calendarEvents.map(
+			(item): CalendarCardCalendarEvent => ({
+				...item,
+				begin: new Date(item.begin),
+				isExam: false
+			})
+		),
+		...exams.map(
+			(item): CalendarCardExamEvent => ({
+				name: item.name,
+				begin: new Date(item.begin),
+				end: item.end,
+				isExam: true,
+				examData: item.examData
+			})
+		)
 	]
-		.map((item) => ({ ...item, begin: new Date(item.begin) }))
 		.filter((x) => x.begin > now || (x.end ?? now) > now)
 		.sort((a, b) => {
 			const dateComparison =
@@ -184,15 +214,15 @@ export function selectCalendarCardEvents(
 			}
 
 			// Same effective time: prioritize exams over calendar events
-			if (a.isExam && !b.isExam) return -1
-			if (!a.isExam && b.isExam) return 1
+			if (isCalendarCardExam(a) && !isCalendarCardExam(b)) return -1
+			if (!isCalendarCardExam(a) && isCalendarCardExam(b)) return 1
 
 			return 0
-		}) as CalendarCardEvent[]
+		})
 
 	// Always pin the next upcoming exam to the first row, then fill the
 	// remaining slot with the chronologically next non-pinned event.
-	const nextExam = combined.find((item) => 'isExam' in item && item.isExam)
+	const nextExam = combined.find(isCalendarCardExam)
 	if (nextExam) {
 		const rest = combined.filter((item) => item !== nextExam)
 		return [nextExam, ...rest].slice(0, 2)

--- a/src/utils/tests/calendar-utils.test.ts
+++ b/src/utils/tests/calendar-utils.test.ts
@@ -68,7 +68,6 @@ const makeExam = (name: string, date: string): Exam => ({
 const toCardExam = (exam: Exam) => ({
 	name: exam.name,
 	begin: new Date(exam.date),
-	isExam: true,
 	examData: exam
 })
 
@@ -180,7 +179,7 @@ describe('calendar-utils', () => {
 			const exams = [toCardExam(makeExam('Math', '2026-07-01T10:00:00'))]
 			const result = calendarUtils.selectCalendarCardEvents(events, exams, NOW)
 			expect(result).toHaveLength(2)
-			expect((result[0] as { isExam?: boolean }).isExam).toBe(true)
+			expect(calendarUtils.isCalendarCardExam(result[0])).toBe(true)
 			expect(idOf(result[1])).toBe('soonEvent')
 		})
 
@@ -191,9 +190,9 @@ describe('calendar-utils', () => {
 				toCardExam(makeExam('EarlyExam', '2026-07-01T10:00:00'))
 			]
 			const result = calendarUtils.selectCalendarCardEvents(events, exams, NOW)
-			expect((result[0] as { examData?: Exam }).examData?.name).toBe(
-				'EarlyExam'
-			)
+			expect(
+				calendarUtils.isCalendarCardExam(result[0]) && result[0].examData.name
+			).toBe('EarlyExam')
 			expect(idOf(result[1])).toBe('soonEvent')
 		})
 

--- a/src/utils/tests/calendar-utils.test.ts
+++ b/src/utils/tests/calendar-utils.test.ts
@@ -1,0 +1,218 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import type { Calendar } from '@/types/data'
+import type { Exam } from '@/types/utils'
+
+const SRC_ROOT = new URL('../../', import.meta.url).pathname
+
+mock.module('react-native', () => ({
+	__esModule: true,
+	default: {
+		Platform: { OS: 'web' }
+	},
+	Platform: { OS: 'web' }
+}))
+
+mock.module('expo-localization', () => ({
+	getLocales: () => [{ languageCode: 'de' }]
+}))
+
+mock.module('react-i18next', () => ({
+	initReactI18next: {}
+}))
+
+mock.module(`${SRC_ROOT}localization/i18n.ts`, () => ({
+	default: { language: 'de' }
+}))
+
+mock.module('i18next', () => ({
+	t: (key: string) => key
+}))
+
+mock.module(`${SRC_ROOT}api/authenticated-api.ts`, () => ({
+	default: {
+		getExams: async () => []
+	}
+}))
+
+let calendarUtils: typeof import('../calendar-utils')
+
+beforeAll(async () => {
+	calendarUtils = await import('../calendar-utils')
+})
+
+const NOW = new Date('2026-06-04T12:00:00')
+
+const makeCalendarEvent = (
+	id: string,
+	begin: string,
+	end?: string
+): Calendar => ({
+	id,
+	name: { de: id, en: id },
+	begin: new Date(begin),
+	end: end ? new Date(end) : undefined
+})
+
+const makeExam = (name: string, date: string): Exam => ({
+	name,
+	type: 'Klausur',
+	rooms: 'A001',
+	seat: '1',
+	notes: '',
+	examiners: [],
+	date: new Date(date),
+	enrollment: new Date('2026-05-01T00:00:00'),
+	aids: []
+})
+
+const toCardExam = (exam: Exam) => ({
+	name: exam.name,
+	begin: new Date(exam.date),
+	isExam: true,
+	examData: exam
+})
+
+const idOf = (event: { id?: string; name: unknown }): string =>
+	'id' in event && event.id
+		? event.id
+		: typeof event.name === 'string'
+			? event.name
+			: ''
+
+describe('calendar-utils', () => {
+	describe('getCalendarCardEffectiveTime', () => {
+		it('uses the begin date for events that have not started yet', () => {
+			const item = {
+				begin: new Date('2026-06-10T00:00:00'),
+				end: new Date('2026-06-20T00:00:00')
+			}
+			expect(calendarUtils.getCalendarCardEffectiveTime(item, NOW)).toBe(
+				item.begin.getTime()
+			)
+		})
+
+		it('uses the end date for events that are already ongoing', () => {
+			const item = {
+				begin: new Date('2026-06-01T00:00:00'),
+				end: new Date('2026-06-20T00:00:00')
+			}
+			expect(calendarUtils.getCalendarCardEffectiveTime(item, NOW)).toBe(
+				item.end.getTime()
+			)
+		})
+
+		it('falls back to begin when no end date is set', () => {
+			const item = { begin: new Date('2026-06-10T00:00:00') }
+			expect(calendarUtils.getCalendarCardEffectiveTime(item, NOW)).toBe(
+				item.begin.getTime()
+			)
+		})
+	})
+
+	describe('selectCalendarCardEvents', () => {
+		it('returns at most two events', () => {
+			const events = [
+				makeCalendarEvent('a', '2026-06-05T00:00:00'),
+				makeCalendarEvent('b', '2026-06-06T00:00:00'),
+				makeCalendarEvent('c', '2026-06-07T00:00:00')
+			]
+			const result = calendarUtils.selectCalendarCardEvents(events, [], NOW)
+			expect(result).toHaveLength(2)
+		})
+
+		it('filters out events that lie completely in the past', () => {
+			const events = [
+				makeCalendarEvent('past', '2026-05-01T00:00:00', '2026-05-10T00:00:00'),
+				makeCalendarEvent('future', '2026-06-10T00:00:00')
+			]
+			const result = calendarUtils.selectCalendarCardEvents(events, [], NOW)
+			expect(result.map(idOf)).toEqual(['future'])
+		})
+
+		it('keeps ongoing multi-day events whose end is still in the future', () => {
+			const events = [
+				makeCalendarEvent(
+					'ongoing',
+					'2026-06-01T00:00:00',
+					'2026-06-20T00:00:00'
+				)
+			]
+			const result = calendarUtils.selectCalendarCardEvents(events, [], NOW)
+			expect(result.map(idOf)).toEqual(['ongoing'])
+		})
+
+		it('sorts by the next relevant moment (upcoming single-day before later end)', () => {
+			// ongoing event ends 2026-06-30, single-day event begins 2026-06-10
+			const events = [
+				makeCalendarEvent(
+					'ongoing',
+					'2026-06-01T00:00:00',
+					'2026-06-30T00:00:00'
+				),
+				makeCalendarEvent('soon', '2026-06-10T00:00:00')
+			]
+			const result = calendarUtils.selectCalendarCardEvents(events, [], NOW)
+			expect(result.map(idOf)).toEqual(['soon', 'ongoing'])
+		})
+
+		it('ranks two ongoing events by their end date', () => {
+			const events = [
+				makeCalendarEvent(
+					'endsLate',
+					'2026-06-01T00:00:00',
+					'2026-07-10T00:00:00'
+				),
+				makeCalendarEvent(
+					'endsSoon',
+					'2026-06-02T00:00:00',
+					'2026-06-15T00:00:00'
+				)
+			]
+			const result = calendarUtils.selectCalendarCardEvents(events, [], NOW)
+			expect(result.map(idOf)).toEqual(['endsSoon', 'endsLate'])
+		})
+
+		it('pins the next exam to the first row even if a calendar event is earlier', () => {
+			const events = [
+				makeCalendarEvent('soonEvent', '2026-06-05T00:00:00'),
+				makeCalendarEvent('laterEvent', '2026-06-08T00:00:00')
+			]
+			const exams = [toCardExam(makeExam('Math', '2026-07-01T10:00:00'))]
+			const result = calendarUtils.selectCalendarCardEvents(events, exams, NOW)
+			expect(result).toHaveLength(2)
+			expect((result[0] as { isExam?: boolean }).isExam).toBe(true)
+			expect(idOf(result[1])).toBe('soonEvent')
+		})
+
+		it('only pins the earliest exam and fills the second slot chronologically', () => {
+			const events = [makeCalendarEvent('soonEvent', '2026-06-05T00:00:00')]
+			const exams = [
+				toCardExam(makeExam('LateExam', '2026-08-01T10:00:00')),
+				toCardExam(makeExam('EarlyExam', '2026-07-01T10:00:00'))
+			]
+			const result = calendarUtils.selectCalendarCardEvents(events, exams, NOW)
+			expect((result[0] as { examData?: Exam }).examData?.name).toBe(
+				'EarlyExam'
+			)
+			expect(idOf(result[1])).toBe('soonEvent')
+		})
+
+		it('returns the two chronologically next events when no exam is present', () => {
+			const events = [
+				makeCalendarEvent('first', '2026-06-05T00:00:00'),
+				makeCalendarEvent('second', '2026-06-06T00:00:00'),
+				makeCalendarEvent('third', '2026-06-07T00:00:00')
+			]
+			const result = calendarUtils.selectCalendarCardEvents(events, [], NOW)
+			expect(result.map(idOf)).toEqual(['first', 'second'])
+		})
+
+		it('returns an empty array when there are no upcoming events', () => {
+			const events = [
+				makeCalendarEvent('past', '2026-05-01T00:00:00', '2026-05-10T00:00:00')
+			]
+			const result = calendarUtils.selectCalendarCardEvents(events, [], NOW)
+			expect(result).toEqual([])
+		})
+	})
+})


### PR DESCRIPTION
## 📋 Description
Closes #324 

This PR reworks the calendar card selection logic.
Calendar events are no longer prioritized by duration (single-day vs. multi-day). Each event is ranked by its next relevant timestamp:
- Not started yet -> start date
- Already ongoing -> end date

The two chronologically next events are selected from this ordering.

**Exception:** Exams -> When upcoming exams are available, the next exam is always shown in the first row, regardless of chronological order. The second row shows the next remaining chronological event (calendar event or exam).

<!-- Please describe the changes you’ve made and the motivation behind them. -->

## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web

- [ ] I’ve added or updated documentation (if needed)
- [ ] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

<!-- Anything else reviewers should be aware of? -->
