### PR TITLE
ci: add coverage checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -40,5 +42,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run unit tests
-        run: bun test --ci
+      - name: Run unit tests with coverage
+        run: bun test --ci --coverage --coverage-reporter=lcov --coverage-reporter=text
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,12 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run unit tests with coverage
-        run: bun test --ci --coverage --coverage-reporter=lcov --coverage-reporter=text
+        run: bun run test:coverage
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
         with:
           files: ./coverage/lcov.info
-          fail_ci_if_error: false
+          fail_ci_if_error: ${{ github.event_name == 'push' }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![CodeQL](https://github.com/neuland-ingolstadt/neuland.app-native/actions/workflows/codeql.yml/badge.svg)](https://github.com/neuland-ingolstadt/neuland.app-native/actions/workflows/codeql.yml)
 [![CI - Biome & Tests](https://github.com/neuland-ingolstadt/neuland.app-native/actions/workflows/ci.yml/badge.svg)](https://github.com/neuland-ingolstadt/neuland.app-native/actions/workflows/ci.yml)
+[![Code Coverage](https://codecov.io/gh/neuland-ingolstadt/neuland.app-native/branch/main/graph/badge.svg?token=U7Y7E7G9R1)](https://codecov.io/gh/neuland-ingolstadt/neuland.app-native)
 # Neuland Next - Your app for THI
 
 <p align="left" style="display: flex; align-items: center; gap: 15px;">

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,3 +2,15 @@
 [install]
 # Only install package versions published at least 3 days ago
 minimumReleaseAge = 259200
+
+[test]
+coverageSkipTestFiles = true
+coveragePathIgnorePatterns = [
+	"src/__generated__/**",
+	"src/data/licenses.json",
+	"src/app/**",
+	"src/components/**",
+	"src/assets/**",
+	"ios/**",
+	"android/**"
+]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+
+comment:
+  layout: reach,diff,flags,files
+  behavior: default
+  require_changes: false
+
+ignore:
+  - src/__generated__
+  - src/data/licenses.json
+  - src/app
+  - src/components
+  - src/assets
+  - ios
+  - android
+  - "**/*.test.ts"
+  - "**/*.web.tsx"
+  - "**/*.ios.tsx"
+  - "**/*.android.tsx"

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,14 +7,17 @@ coverage:
       default:
         target: auto
         threshold: 1%
+        base: auto
     patch:
       default:
         target: auto
+        base: auto
 
 comment:
   layout: reach,diff,flags,files
   behavior: default
   require_changes: false
+  hide_project_coverage: false
 
 ignore:
   - src/__generated__

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
 		"licences": "npm-license-crawler -onlyDirectDependencies -json src/data/licenses.json",
 		"codegen": "graphql-codegen --config config/codegen.yml",
 		"changelog": "git cliff --config config/cliff.toml --output CHANGELOG.md",
-		"pkgs": "bunx expo install --check"
+		"pkgs": "bunx expo install --check",
+		"test": "bun test --ci",
+		"test:coverage": "bun test --ci --coverage --coverage-reporter=lcov --coverage-reporter=text"
 	},
 	"dependencies": {
 		"@aptabase/react-native": "^0.3.10",


### PR DESCRIPTION
Closes #362.

- Added Codecov configuration file to manage coverage reporting.
- Updated bunfig.toml to skip coverage for specific test files and paths.
- Modified package.json to include new test and coverage scripts.
- Enhanced CI workflow to run unit tests with coverage and upload results to Codecov.