### PR TITLE
fix: update query key for timetable data retrieval

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,6 +26,12 @@ ios:
   - changed-files:
       - any-glob-to-any-file: 'ios/**'
 
+web:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.web.tsx'
+          - '**/*.html'
+
 dependencies:
   - changed-files:
       - any-glob-to-any-file:

--- a/src/components/Map/map-screen.web.tsx
+++ b/src/components/Map/map-screen.web.tsx
@@ -182,7 +182,7 @@ const MapScreen = (): React.JSX.Element => {
 	}, [overlayError])
 
 	const { data: timetable } = useQuery({
-		queryKey: ['2', userKind],
+		queryKey: ['timetableV2', userKind],
 		queryFn: loadTimetable,
 		staleTime: 1000 * 60 * 10, // 10 minutes
 		gcTime: 1000 * 60 * 60 * 24 * 7, // 1 week


### PR DESCRIPTION
Closes #361.

This pull request makes a minor update to the cache key used in the `useQuery` hook for loading timetables. The new key is more descriptive, which will help prevent cache collisions and improve maintainability.

- Changed the `queryKey` in the `useQuery` hook from `['2', userKind]` to `['timetableV2', userKind]` in `map-screen.web.tsx` to use a clearer, more descriptive cache key.