### PR TITLE
chore: expand PR auto-labeling configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,17 +20,47 @@ documentation:
 
 android:
   - changed-files:
-      - any-glob-to-any-file: 'android/**'
+      - any-glob-to-any-file:
+          - 'android/**'
+          - '**/*.android.tsx'
 
 ios:
   - changed-files:
-      - any-glob-to-any-file: 'ios/**'
+      - any-glob-to-any-file:
+          - 'ios/**'
+          - '**/*.ios.tsx'
 
 web:
   - changed-files:
       - any-glob-to-any-file:
           - '**/*.web.tsx'
           - '**/*.html'
+
+i18n:
+  - changed-files:
+      - any-glob-to-any-file: 'src/localization/**'
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/utils/tests/**'
+          - '**/*.test.ts'
+
+api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/api/**'
+          - 'src/__generated__/**'
+          - 'config/codegen.yml'
+
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app.config.json'
+          - 'eas.json'
+          - 'babel.config.js'
+          - 'tsconfig.json'
+          - 'config/plugins/**'
 
 dependencies:
   - changed-files:


### PR DESCRIPTION
## Summary

- Extend `android` / `ios` labeler rules to include `**/*.android.tsx` and `**/*.ios.tsx` platform overrides in `src/`
- Add auto-labeling for `web`, `i18n`, `tests`, `api`, and `config` path patterns
- Create matching GitHub labels (`i18n`, `tests`, `api`, `config`) and align `web` description with other platform labels

Closes #340

## Test plan

- [ ] Open or sync a PR that touches `*.web.tsx` files and confirm the `web` label is applied
- [ ] Open or sync a PR that touches `src/localization/**` and confirm the `i18n` label is applied
- [ ] Open or sync a PR that touches `src/utils/tests/**` or `*.test.ts` and confirm the `tests` label is applied
- [ ] Open or sync a PR that touches `src/api/**` or `src/__generated__/**` and confirm the `api` label is applied
- [ ] Open or sync a PR that touches `app.config.json` or `config/plugins/**` and confirm the `config` label is applied
- [ ] Verify `android` / `ios` labels apply when only `*.android.tsx` / `*.ios.tsx` files change (no native folder edits)