### PR TITLE
test: boost utility module coverage

### DIFF
--- a/src/utils/tests/calendar-utils.test.ts
+++ b/src/utils/tests/calendar-utils.test.ts
@@ -1,8 +1,11 @@
 import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import type { i18n } from 'i18next'
 import type { Calendar } from '@/types/data'
 import type { Exam } from '@/types/utils'
 
 const SRC_ROOT = new URL('../../', import.meta.url).pathname
+
+const mockGetExams = mock(async () => [] as never[])
 
 mock.module('react-native', () => ({
 	__esModule: true,
@@ -30,7 +33,7 @@ mock.module('i18next', () => ({
 
 mock.module(`${SRC_ROOT}api/authenticated-api.ts`, () => ({
 	default: {
-		getExams: async () => []
+		getExams: mockGetExams
 	}
 }))
 
@@ -212,6 +215,153 @@ describe('calendar-utils', () => {
 			]
 			const result = calendarUtils.selectCalendarCardEvents(events, [], NOW)
 			expect(result).toEqual([])
+		})
+
+		it('prioritizes exams over calendar events when effective times tie', () => {
+			const sameBegin = new Date('2026-06-10T00:00:00')
+			const events = [
+				{
+					...makeCalendarEvent('calendar', '2026-06-10T00:00:00'),
+					begin: sameBegin
+				}
+			]
+			const exams = [
+				{
+					...toCardExam(makeExam('TiedExam', '2026-06-10T00:00:00')),
+					begin: sameBegin
+				}
+			]
+			const result = calendarUtils.selectCalendarCardEvents(events, exams, NOW)
+			expect(calendarUtils.isCalendarCardExam(result[0])).toBe(true)
+			expect(
+				calendarUtils.isCalendarCardExam(result[0]) && result[0].examData.name
+			).toBe('TiedExam')
+		})
+	})
+
+	describe('loadExamList', () => {
+		it('returns an empty array when the API has no exams', async () => {
+			mockGetExams.mockReset()
+			mockGetExams.mockResolvedValue([])
+
+			await expect(calendarUtils.loadExamList()).resolves.toEqual([])
+		})
+
+		it('filters internship-like exams and maps API fields', async () => {
+			mockGetExams.mockReset()
+			mockGetExams.mockResolvedValue([
+				{
+					titel: 'Praktikum',
+					pruefungs_art: 'Praktikum',
+					exam_rooms: '',
+					exam_seat: '',
+					anmerkung: '',
+					pruefer_namen: [],
+					exam_ts: new Date('2026-08-01T10:00:00'),
+					anm_ts: new Date('2026-07-01T00:00:00'),
+					hilfsmittel: ['Notes'],
+					modus: '2'
+				},
+				{
+					titel: 'Mathematik',
+					pruefungs_art: 'Klausur',
+					exam_rooms: 'A101',
+					exam_seat: '12',
+					anmerkung: 'Taschenrechner erlaubt',
+					pruefer_namen: ['Prof. X'],
+					exam_ts: new Date('2026-07-01T10:00:00'),
+					anm_ts: new Date('2026-06-01T00:00:00'),
+					hilfsmittel: ['Calculator', 'Calculator'],
+					modus: '1'
+				}
+			])
+
+			const result = await calendarUtils.loadExamList()
+
+			expect(result).toHaveLength(1)
+			expect(result[0]).toEqual({
+				name: 'Mathematik',
+				type: 'Klausur',
+				rooms: 'A101',
+				seat: '12',
+				notes: 'Taschenrechner erlaubt',
+				examiners: ['Prof. X'],
+				date: new Date('2026-07-01T10:00:00'),
+				enrollment: new Date('2026-06-01T00:00:00'),
+				aids: ['Calculator']
+			})
+		})
+	})
+
+	describe('convertCalendarToWeekViewEvents', () => {
+		const i18nMock = { language: 'de' } as i18n
+
+		it('maps all-day events to midnight boundaries', () => {
+			const entries: Calendar[] = [
+				{
+					id: 'holiday',
+					name: { de: 'Feiertag', en: 'Holiday' },
+					begin: new Date('2026-06-04T00:00:00'),
+					end: new Date('2026-06-05T00:00:00'),
+					hasHours: false
+				}
+			]
+
+			const [event] = calendarUtils.convertCalendarToWeekViewEvents(
+				entries,
+				i18nMock,
+				'#123456',
+				'#ffffff'
+			)
+
+			expect(event.title).toBe('Feiertag')
+			expect(event.color).toBe('#123456')
+			expect(event.textColor).toBe('#ffffff')
+			expect(event.start.getHours()).toBe(0)
+			expect(event.end.getHours()).toBe(0)
+		})
+
+		it('keeps timed events at their original start and end', () => {
+			const begin = new Date('2026-06-04T08:15:00')
+			const end = new Date('2026-06-04T09:45:00')
+			const entries: Calendar[] = [
+				{
+					id: 'lecture',
+					name: { de: 'Vorlesung', en: 'Lecture' },
+					begin,
+					end,
+					hasHours: true
+				}
+			]
+
+			const [event] = calendarUtils.convertCalendarToWeekViewEvents(
+				entries,
+				i18nMock,
+				'#654321',
+				'#000000'
+			)
+
+			expect(event.start).toBe(begin)
+			expect(event.end).toBe(end)
+			expect(event.title).toBe('Vorlesung')
+		})
+	})
+
+	describe('getNextReRegistrationEvent', () => {
+		it('returns the soonest upcoming re-registration event', () => {
+			const event = calendarUtils.getNextReRegistrationEvent(
+				new Date('2026-06-01T00:00:00')
+			)
+
+			expect(event?.id).toBe('rereg-ws26-ss26')
+		})
+
+		it('returns undefined when no re-registration event lies in the future', () => {
+			expect(
+				calendarUtils.getNextReRegistrationEvent(
+					new Date('2028-01-01T00:00:00')
+				)
+			).toBeUndefined()
 		})
 	})
 })

--- a/src/utils/tests/calendar-utils.test.ts
+++ b/src/utils/tests/calendar-utils.test.ts
@@ -1,11 +1,12 @@
 import { beforeAll, describe, expect, it, mock } from 'bun:test'
 import type { i18n } from 'i18next'
 import type { Calendar } from '@/types/data'
+import type { Exams } from '@/types/thi-api'
 import type { Exam } from '@/types/utils'
 
 const SRC_ROOT = new URL('../../', import.meta.url).pathname
 
-const mockGetExams = mock(async () => [] as never[])
+const mockGetExams = mock(async (): Promise<Exams[]> => [])
 
 mock.module('react-native', () => ({
 	__esModule: true,
@@ -258,10 +259,13 @@ describe('calendar-utils', () => {
 					anmerkung: '',
 					pruefer_namen: [],
 					exam_ts: new Date('2026-08-01T10:00:00'),
+					exm_date: new Date('2026-08-01T00:00:00'),
+					exam_time: new Date('2026-08-01T10:00:00'),
 					anm_ts: new Date('2026-07-01T00:00:00'),
 					hilfsmittel: ['Notes'],
-					modus: '2'
-				},
+					modus: '2',
+					ancode: 'P'
+				} as Exams,
 				{
 					titel: 'Mathematik',
 					pruefungs_art: 'Klausur',
@@ -270,10 +274,13 @@ describe('calendar-utils', () => {
 					anmerkung: 'Taschenrechner erlaubt',
 					pruefer_namen: ['Prof. X'],
 					exam_ts: new Date('2026-07-01T10:00:00'),
+					exm_date: new Date('2026-07-01T00:00:00'),
+					exam_time: new Date('2026-07-01T10:00:00'),
 					anm_ts: new Date('2026-06-01T00:00:00'),
 					hilfsmittel: ['Calculator', 'Calculator'],
-					modus: '1'
-				}
+					modus: '1',
+					ancode: 'K'
+				} as Exams
 			])
 
 			const result = await calendarUtils.loadExamList()

--- a/src/utils/tests/calendar-utils.test.ts
+++ b/src/utils/tests/calendar-utils.test.ts
@@ -355,19 +355,39 @@ describe('calendar-utils', () => {
 	})
 
 	describe('getNextReRegistrationEvent', () => {
-		it('returns the soonest upcoming re-registration event', () => {
-			const event = calendarUtils.getNextReRegistrationEvent(
-				new Date('2026-06-01T00:00:00')
-			)
+		const getReregEvents = () =>
+			calendarUtils.calendar.filter((event) => event.id.startsWith('rereg-'))
 
-			expect(event?.id).toBe('rereg-ws26-ss26')
+		it('returns the soonest upcoming re-registration event', () => {
+			const reregEvents = getReregEvents()
+			expect(reregEvents.length).toBeGreaterThan(0)
+
+			const earliestBegin = reregEvents.reduce(
+				(min, event) => Math.min(min, event.begin.getTime()),
+				Number.POSITIVE_INFINITY
+			)
+			const referenceDate = new Date(earliestBegin - 86_400_000)
+			const expected = [...reregEvents]
+				.filter((event) => event.begin > referenceDate)
+				.sort((a, b) => a.begin.getTime() - b.begin.getTime())[0]
+
+			expect(calendarUtils.getNextReRegistrationEvent(referenceDate)).toEqual(
+				expected
+			)
 		})
 
 		it('returns undefined when no re-registration event lies in the future', () => {
+			const reregEvents = getReregEvents()
+			expect(reregEvents.length).toBeGreaterThan(0)
+
+			const latestBegin = reregEvents.reduce(
+				(max, event) => Math.max(max, event.begin.getTime()),
+				Number.NEGATIVE_INFINITY
+			)
+			const referenceDate = new Date(latestBegin + 86_400_000)
+
 			expect(
-				calendarUtils.getNextReRegistrationEvent(
-					new Date('2028-01-01T00:00:00')
-				)
+				calendarUtils.getNextReRegistrationEvent(referenceDate)
 			).toBeUndefined()
 		})
 	})

--- a/src/utils/tests/date-utils.test.ts
+++ b/src/utils/tests/date-utils.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import { beforeAll, describe, expect, it, mock, spyOn } from 'bun:test'
 
 const SRC_ROOT = new URL('../../', import.meta.url).pathname
 
@@ -209,6 +209,17 @@ describe('date-utils', () => {
 	})
 
 	describe('friendly formatters', () => {
+		const FIXED_NOW = Date.parse('2026-04-07T12:00:00')
+
+		const withFrozenNow = (run: () => void): void => {
+			const nowSpy = spyOn(Date, 'now').mockReturnValue(FIXED_NOW)
+			try {
+				run()
+			} finally {
+				nowSpy.mockRestore()
+			}
+		}
+
 		const fixedDate = (isoDate: string, hours = 8, minutes = 0): Date =>
 			new Date(
 				`${isoDate}T${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:00`
@@ -358,20 +369,26 @@ describe('date-utils', () => {
 		})
 
 		it('formatFriendlyRelativeTime - Should return a relative label for future dates', () => {
-			const inFiveMinutes = new Date(Date.now() + 5 * 60 * 1000)
-			expect(dateUtils.formatFriendlyRelativeTime(inFiveMinutes)).toBe(
-				'in 5 Minuten'
-			)
+			withFrozenNow(() => {
+				const inFiveMinutes = new Date(FIXED_NOW + 5 * 60 * 1000)
+				expect(dateUtils.formatFriendlyRelativeTime(inFiveMinutes)).toBe(
+					'in 5 Minuten'
+				)
+			})
 		})
 
 		it('formatRelativeMinutes - Should count minutes until a future datetime', () => {
-			const inTenMinutes = new Date(Date.now() + 10 * 60 * 1000)
-			expect(dateUtils.formatRelativeMinutes(inTenMinutes)).toBe('10 min')
+			withFrozenNow(() => {
+				const inTenMinutes = new Date(FIXED_NOW + 10 * 60 * 1000)
+				expect(dateUtils.formatRelativeMinutes(inTenMinutes)).toBe('10 min')
+			})
 		})
 
 		it('formatRelativeMinutes - Should not return negative minute counts', () => {
-			const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000)
-			expect(dateUtils.formatRelativeMinutes(oneHourAgo)).toBe('0 min')
+			withFrozenNow(() => {
+				const oneHourAgo = new Date(FIXED_NOW - 60 * 60 * 1000)
+				expect(dateUtils.formatRelativeMinutes(oneHourAgo)).toBe('0 min')
+			})
 		})
 
 		it('getFriendlyWeek - Should label the current and next week relatively', () => {

--- a/src/utils/tests/date-utils.test.ts
+++ b/src/utils/tests/date-utils.test.ts
@@ -412,7 +412,10 @@ describe('date-utils', () => {
 		})
 
 		it('formatDay - Should format weekday and day using the active locale', () => {
-			expect(dateUtils.formatDay(fixedDate('2026-04-09'))).toBe('Do. 09.')
+			const date = fixedDate('2026-04-09')
+			expect(dateUtils.formatDay(date)).toBe(
+				date.toLocaleString('de', { weekday: 'short', day: '2-digit' })
+			)
 		})
 	})
 })

--- a/src/utils/tests/date-utils.test.ts
+++ b/src/utils/tests/date-utils.test.ts
@@ -207,4 +207,197 @@ describe('date-utils', () => {
 			)
 		).toBe('07.04 - 09.04')
 	})
+
+	describe('friendly formatters', () => {
+		const fixedDate = (isoDate: string, hours = 8, minutes = 0): Date =>
+			new Date(`${isoDate}T${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:00`)
+
+		const todayAt = (hours = 8, minutes = 0): Date => {
+			const now = new Date()
+			return new Date(
+				now.getFullYear(),
+				now.getMonth(),
+				now.getDate(),
+				hours,
+				minutes
+			)
+		}
+
+		const tomorrowAt = (hours = 8, minutes = 0): Date => {
+			const date = todayAt(hours, minutes)
+			date.setDate(date.getDate() + 1)
+			return date
+		}
+
+		it('formatFriendlyDate - Should return the today label for the current day', () => {
+			expect(dateUtils.formatFriendlyDate(todayAt())).toBe('dates.today')
+		})
+
+		it('formatFriendlyDate - Should return the tomorrow label for the next day', () => {
+			expect(dateUtils.formatFriendlyDate(tomorrowAt())).toBe('dates.tomorrow')
+		})
+
+		it('formatFriendlyDate - Should format other days with weekday and German date', () => {
+			expect(dateUtils.formatFriendlyDate(fixedDate('2026-04-09'))).toBe(
+				'Do., 09.04.2026'
+			)
+		})
+
+		it('formatFriendlyDate - Should skip relative labels when relative is false', () => {
+			expect(
+				dateUtils.formatFriendlyDate(todayAt(), {
+					relative: false,
+					weekday: 'short'
+				})
+			).toMatch(/, \d{2}\.\d{2}\.\d{4}$/)
+		})
+
+		it('formatFriendlyDate - Should support long weekday names', () => {
+			expect(
+				dateUtils.formatFriendlyDate(fixedDate('2026-04-09'), {
+					relative: false,
+					weekday: 'long'
+				})
+			).toBe('Donnerstag, 09.04.2026')
+		})
+
+		it('formatFriendlyDateRange - Should return only the begin date for same-day ranges', () => {
+			expect(
+				dateUtils.formatFriendlyDateRange(
+					fixedDate('2026-04-09'),
+					fixedDate('2026-04-09', 20)
+				)
+			).toBe('Do., 09.04.2026')
+		})
+
+		it('formatFriendlyDateRange - Should join different days with a range separator', () => {
+			expect(
+				dateUtils.formatFriendlyDateRange(
+					fixedDate('2026-04-09'),
+					fixedDate('2026-04-10')
+				)
+			).toBe('Do., 09.04.2026 – Fr., 10.04.2026')
+		})
+
+		it('formatFriendlyTime - Should format valid datetimes as HH:mm', () => {
+			expect(dateUtils.formatFriendlyTime(fixedDate('2026-04-07', 8, 15))).toBe(
+				'08:15'
+			)
+		})
+
+		it('formatFriendlyTime - Should return an empty string for missing or invalid input', () => {
+			expect(dateUtils.formatFriendlyTime(undefined)).toBe('')
+			expect(dateUtils.formatFriendlyTime('not-a-date')).toBe('')
+		})
+
+		it('formatFriendlyTimeString - Should trim seconds from a time string', () => {
+			expect(dateUtils.formatFriendlyTimeString('08:30:45')).toBe('08:30')
+		})
+
+		it('formatFriendlyTimeRange - Should format a single time or a range', () => {
+			expect(dateUtils.formatFriendlyTimeRange('08:00:00')).toBe('08:00')
+			expect(
+				dateUtils.formatFriendlyTimeRange('08:00:00', '12:30:00')
+			).toBe('08:00 – 12:30')
+		})
+
+		it('formatFriendlyDateTimeRange - Should return an empty string without a begin date', () => {
+			expect(dateUtils.formatFriendlyDateTimeRange(null, null)).toBe('')
+		})
+
+		it('formatFriendlyDateTimeRange - Should format same-day ranges with one date label', () => {
+			expect(
+				dateUtils.formatFriendlyDateTimeRange(
+					fixedDate('2026-04-09', 8),
+					fixedDate('2026-04-09', 12, 30)
+				)
+			).toBe('Do., 09.04.2026, 08:00 – 12:30')
+		})
+
+		it('formatFriendlyDateTimeRange - Should repeat the date when the range spans days', () => {
+			expect(
+				dateUtils.formatFriendlyDateTimeRange(
+					fixedDate('2026-04-09', 8),
+					fixedDate('2026-04-10', 12, 30)
+				)
+			).toBe(
+				'Do., 09.04.2026, 08:00 – Fr., 10.04.2026, 12:30'
+			)
+		})
+
+		it('formatFriendlyDateTime - Should handle missing, sentinel and valid dates', () => {
+			expect(dateUtils.formatFriendlyDateTime(undefined)).toBe(
+				'No date available'
+			)
+			expect(dateUtils.formatFriendlyDateTime('invalid')).toBe(
+				'No date available'
+			)
+			expect(
+				dateUtils.formatFriendlyDateTime(new Date('1970-01-01T00:00:00'))
+			).toBe(null)
+			expect(dateUtils.formatFriendlyDateTime(fixedDate('2026-04-09', 8, 15))).toBe(
+				'Do., 09.04.2026, 08:15'
+			)
+		})
+
+		it('formatNearDate - Should return today and tomorrow labels or a near date', () => {
+			expect(dateUtils.formatNearDate(todayAt())).toBe('dates.today')
+			expect(dateUtils.formatNearDate(tomorrowAt())).toBe('dates.tomorrow')
+			expect(dateUtils.formatNearDate(fixedDate('2026-04-09'))).toBe(
+				'Donnerstag, 9.4.'
+			)
+		})
+
+		it('formatFriendlyRelativeTime - Should reject sentinel and invalid dates', () => {
+			expect(
+				dateUtils.formatFriendlyRelativeTime(new Date('1970-01-01T00:00:00'))
+			).toBe('')
+			expect(
+				dateUtils.formatFriendlyRelativeTime(new Date(Number.NaN))
+			).toBe('')
+		})
+
+		it('formatFriendlyRelativeTime - Should return a relative label for future dates', () => {
+			const inFiveMinutes = new Date(Date.now() + 5 * 60 * 1000)
+			expect(dateUtils.formatFriendlyRelativeTime(inFiveMinutes)).toBe(
+				'in 5 Minuten'
+			)
+		})
+
+		it('formatRelativeMinutes - Should count minutes until a future datetime', () => {
+			const inTenMinutes = new Date(Date.now() + 10 * 60 * 1000)
+			expect(dateUtils.formatRelativeMinutes(inTenMinutes)).toBe('10 min')
+		})
+
+		it('formatRelativeMinutes - Should not return negative minute counts', () => {
+			const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000)
+			expect(dateUtils.formatRelativeMinutes(oneHourAgo)).toBe('0 min')
+		})
+
+		it('getFriendlyWeek - Should label the current and next week relatively', () => {
+			const [currentWeekStart, currentWeekEnd] = dateUtils.getWeek(new Date())
+			const inCurrentWeek = new Date(currentWeekStart)
+			inCurrentWeek.setDate(inCurrentWeek.getDate() + 1)
+
+			const inNextWeek = new Date(currentWeekEnd)
+			inNextWeek.setDate(inNextWeek.getDate() + 1)
+
+			expect(dateUtils.getFriendlyWeek(inCurrentWeek, 'de')).toBe(
+				'dates.thisWeek'
+			)
+			expect(dateUtils.getFriendlyWeek(inNextWeek, 'de')).toBe(
+				'dates.nextWeek'
+			)
+		})
+
+		it('getFriendlyWeek - Should format arbitrary weeks as a numeric range', () => {
+			expect(
+				dateUtils.getFriendlyWeek(fixedDate('2025-01-15'), 'de')
+			).toBe('13.1. – 19.1.')
+		})
+
+		it('formatDay - Should format weekday and day using the active locale', () => {
+			expect(dateUtils.formatDay(fixedDate('2026-04-09'))).toBe('Do. 09.')
+		})
+	})
 })

--- a/src/utils/tests/date-utils.test.ts
+++ b/src/utils/tests/date-utils.test.ts
@@ -210,7 +210,9 @@ describe('date-utils', () => {
 
 	describe('friendly formatters', () => {
 		const fixedDate = (isoDate: string, hours = 8, minutes = 0): Date =>
-			new Date(`${isoDate}T${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:00`)
+			new Date(
+				`${isoDate}T${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:00`
+			)
 
 		const todayAt = (hours = 8, minutes = 0): Date => {
 			const now = new Date()
@@ -296,9 +298,9 @@ describe('date-utils', () => {
 
 		it('formatFriendlyTimeRange - Should format a single time or a range', () => {
 			expect(dateUtils.formatFriendlyTimeRange('08:00:00')).toBe('08:00')
-			expect(
-				dateUtils.formatFriendlyTimeRange('08:00:00', '12:30:00')
-			).toBe('08:00 – 12:30')
+			expect(dateUtils.formatFriendlyTimeRange('08:00:00', '12:30:00')).toBe(
+				'08:00 – 12:30'
+			)
 		})
 
 		it('formatFriendlyDateTimeRange - Should return an empty string without a begin date', () => {
@@ -320,9 +322,7 @@ describe('date-utils', () => {
 					fixedDate('2026-04-09', 8),
 					fixedDate('2026-04-10', 12, 30)
 				)
-			).toBe(
-				'Do., 09.04.2026, 08:00 – Fr., 10.04.2026, 12:30'
-			)
+			).toBe('Do., 09.04.2026, 08:00 – Fr., 10.04.2026, 12:30')
 		})
 
 		it('formatFriendlyDateTime - Should handle missing, sentinel and valid dates', () => {
@@ -335,9 +335,9 @@ describe('date-utils', () => {
 			expect(
 				dateUtils.formatFriendlyDateTime(new Date('1970-01-01T00:00:00'))
 			).toBe(null)
-			expect(dateUtils.formatFriendlyDateTime(fixedDate('2026-04-09', 8, 15))).toBe(
-				'Do., 09.04.2026, 08:15'
-			)
+			expect(
+				dateUtils.formatFriendlyDateTime(fixedDate('2026-04-09', 8, 15))
+			).toBe('Do., 09.04.2026, 08:15')
 		})
 
 		it('formatNearDate - Should return today and tomorrow labels or a near date', () => {
@@ -352,9 +352,9 @@ describe('date-utils', () => {
 			expect(
 				dateUtils.formatFriendlyRelativeTime(new Date('1970-01-01T00:00:00'))
 			).toBe('')
-			expect(
-				dateUtils.formatFriendlyRelativeTime(new Date(Number.NaN))
-			).toBe('')
+			expect(dateUtils.formatFriendlyRelativeTime(new Date(Number.NaN))).toBe(
+				''
+			)
 		})
 
 		it('formatFriendlyRelativeTime - Should return a relative label for future dates', () => {
@@ -385,15 +385,13 @@ describe('date-utils', () => {
 			expect(dateUtils.getFriendlyWeek(inCurrentWeek, 'de')).toBe(
 				'dates.thisWeek'
 			)
-			expect(dateUtils.getFriendlyWeek(inNextWeek, 'de')).toBe(
-				'dates.nextWeek'
-			)
+			expect(dateUtils.getFriendlyWeek(inNextWeek, 'de')).toBe('dates.nextWeek')
 		})
 
 		it('getFriendlyWeek - Should format arbitrary weeks as a numeric range', () => {
-			expect(
-				dateUtils.getFriendlyWeek(fixedDate('2025-01-15'), 'de')
-			).toBe('13.1. – 19.1.')
+			expect(dateUtils.getFriendlyWeek(fixedDate('2025-01-15'), 'de')).toBe(
+				'13.1. – 19.1.'
+			)
 		})
 
 		it('formatDay - Should format weekday and day using the active locale', () => {

--- a/src/utils/tests/food-utils.test.ts
+++ b/src/utils/tests/food-utils.test.ts
@@ -1,7 +1,15 @@
 import { beforeAll, describe, expect, it, mock } from 'bun:test'
-import type { Name } from '@/types/neuland-api'
+import type { i18n } from 'i18next'
+import type { Meal, Name } from '@/types/neuland-api'
 
 const SRC_ROOT = new URL('../../', import.meta.url).pathname
+
+const platform = { OS: 'web' as 'web' | 'ios' | 'android' }
+const shareMock = mock(async () => {})
+const copyToClipboardMock = mock(async () => {})
+const trackEventMock = mock(() => {})
+const mockGetFoodPlan = mock(async () => ({ food: [] }))
+const mockGetFragmentData = mock(() => ({ foodData: [] as unknown[] }))
 
 mock.module(`${SRC_ROOT}localization/i18n.ts`, () => ({
 	default: { language: 'de' }
@@ -18,8 +26,8 @@ mock.module('react-i18next', () => ({
 mock.module('react-native', () => ({
 	__esModule: true,
 	default: {
-		Platform: { OS: 'web' },
-		Share: { share: () => Promise.resolve() },
+		Platform: platform,
+		Share: { share: shareMock },
 		NativeEventEmitter: class {
 			addListener() {
 				return { remove: () => {} }
@@ -31,8 +39,8 @@ mock.module('react-native', () => ({
 			getEnforcing: () => null
 		}
 	},
-	Platform: { OS: 'web' },
-	Share: { share: () => Promise.resolve() },
+	Platform: platform,
+	Share: { share: shareMock },
 	NativeEventEmitter: class {
 		addListener() {
 			return { remove: () => {} }
@@ -46,7 +54,7 @@ mock.module('react-native', () => ({
 }))
 
 mock.module('@aptabase/react-native', () => ({
-	trackEvent: () => {}
+	trackEvent: trackEventMock
 }))
 
 mock.module('expo-clipboard', () => ({
@@ -57,8 +65,12 @@ mock.module('burnt', () => ({
 	toast: () => {}
 }))
 
+mock.module(`${SRC_ROOT}utils/ui-utils.ts`, () => ({
+	copyToClipboard: copyToClipboardMock
+}))
+
 mock.module(`${SRC_ROOT}__generated__/gql/index.ts`, () => ({
-	getFragmentData: () => ({ foodData: [] })
+	getFragmentData: mockGetFragmentData
 }))
 
 mock.module(`${SRC_ROOT}__generated__/gql/graphql.ts`, () => ({
@@ -67,13 +79,38 @@ mock.module(`${SRC_ROOT}__generated__/gql/graphql.ts`, () => ({
 
 mock.module(`${SRC_ROOT}api/neuland-api.ts`, () => ({
 	default: {
-		getFoodPlan: async () => ({
-			food: []
-		})
+		getFoodPlan: mockGetFoodPlan
 	}
 }))
 
 let foodUtils: typeof import('../food-utils')
+
+const formatYmd = (date: Date): string =>
+	`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+
+const weekdayIsoDates = (): string[] =>
+	Array.from({ length: 7 }, (_, index) => {
+		const date = new Date()
+		date.setDate(date.getDate() + index)
+		return date
+	})
+		.filter((date) => date.getDay() !== 0 && date.getDay() !== 6)
+		.map(formatYmd)
+
+const makeMeal = (id: string, isStatic: boolean): Meal =>
+	({
+		id,
+		static: isStatic,
+		name: { de: `Gericht ${id}`, en: `Meal ${id}` },
+		category: 'Hauptgericht',
+		prices: { guest: 4.5, employee: 3.5, student: 2.5 },
+		allergens: null,
+		flags: null,
+		nutrition: null,
+		variants: [],
+		originalLanguage: 'de',
+		restaurant: 'IngolstadtMensa'
+	}) as Meal
 
 beforeAll(async () => {
 	foodUtils = await import('../food-utils')
@@ -245,5 +282,120 @@ describe('food-utils', () => {
 			flags: null
 		}
 		expect(foodUtils.userMealRating(meal as never, ['Ei'], ['V'])).toBe(0)
+	})
+
+	it('loadFoodEntries - Should map weekday meal plans and exclude static meals by default', async () => {
+		const isoDates = weekdayIsoDates()
+		const targetDay = isoDates[0] as string
+
+		mockGetFoodPlan.mockReset()
+		mockGetFragmentData.mockReset()
+		mockGetFoodPlan.mockResolvedValue({ food: 'graphql-payload' })
+		mockGetFragmentData.mockReturnValue({
+			foodData: [
+				{
+					timestamp: targetDay,
+					meals: [makeMeal('static', true), makeMeal('daily', false)]
+				}
+			]
+		})
+
+		const result = await foodUtils.loadFoodEntries(['IngolstadtMensa'])
+
+		expect(mockGetFoodPlan).toHaveBeenCalledWith(['IngolstadtMensa'])
+		expect(result).toHaveLength(isoDates.length)
+		expect(result.map((entry) => entry.timestamp)).toEqual(isoDates)
+		expect(
+			result.find((entry) => entry.timestamp === targetDay)?.meals
+		).toEqual([makeMeal('daily', false)])
+	})
+
+	it('loadFoodEntries - Should keep static meals when includeStatic is true', async () => {
+		const targetDay = weekdayIsoDates()[0] as string
+
+		mockGetFoodPlan.mockReset()
+		mockGetFragmentData.mockReset()
+		mockGetFoodPlan.mockResolvedValue({ food: 'graphql-payload' })
+		mockGetFragmentData.mockReturnValue({
+			foodData: [
+				{
+					timestamp: targetDay,
+					meals: [makeMeal('static', true), makeMeal('daily', false)]
+				}
+			]
+		})
+
+		const result = await foodUtils.loadFoodEntries(['IngolstadtMensa'], true)
+
+		expect(
+			result.find((entry) => entry.timestamp === targetDay)?.meals
+		).toEqual([makeMeal('static', true), makeMeal('daily', false)])
+	})
+
+	it('shareMeal - Should track analytics and copy the message on web', () => {
+		platform.OS = 'web'
+		trackEventMock.mockReset()
+		copyToClipboardMock.mockReset()
+		shareMock.mockReset()
+
+		const meal = makeMeal('share-meal', false)
+		const i18nMock = {
+			language: 'de',
+			t: (
+				key: string,
+				options?: {
+					ns?: string
+					meal?: string
+					price?: string
+					location?: string
+					id?: string
+				}
+			) =>
+				key === 'details.share.message'
+					? `share:${options?.meal}:${options?.price}:${options?.location}:${options?.id}`
+					: key
+		} as i18n
+
+		foodUtils.shareMeal(meal, i18nMock, 'student')
+
+		expect(trackEventMock).toHaveBeenCalledWith('Share', { type: 'meal' })
+		expect(copyToClipboardMock).toHaveBeenCalledWith(
+			'share:Gericht share-meal:2.50 €:Mensa Ingolstadt:share-meal'
+		)
+		expect(shareMock).not.toHaveBeenCalled()
+	})
+
+	it('shareMeal - Should open the native share sheet off web', () => {
+		platform.OS = 'ios'
+		trackEventMock.mockReset()
+		copyToClipboardMock.mockReset()
+		shareMock.mockReset()
+
+		const meal = makeMeal('native-meal', false)
+		const i18nMock = {
+			language: 'de',
+			t: (
+				key: string,
+				options?: {
+					ns?: string
+					meal?: string
+					price?: string
+					location?: string
+					id?: string
+				}
+			) =>
+				key === 'details.share.message'
+					? `native:${options?.meal}:${options?.id}`
+					: key
+		} as i18n
+
+		foodUtils.shareMeal(meal, i18nMock, 'guest')
+
+		expect(shareMock).toHaveBeenCalledWith({
+			message: 'native:Gericht native-meal:native-meal'
+		})
+		expect(copyToClipboardMock).not.toHaveBeenCalled()
+
+		platform.OS = 'web'
 	})
 })

--- a/src/utils/tests/food-utils.test.ts
+++ b/src/utils/tests/food-utils.test.ts
@@ -8,7 +8,7 @@ const platform = { OS: 'web' as 'web' | 'ios' | 'android' }
 const shareMock = mock(async () => {})
 const copyToClipboardMock = mock(async () => {})
 const trackEventMock = mock(() => {})
-const mockGetFoodPlan = mock(async () => ({ food: [] }))
+const mockGetFoodPlan = mock(async (): Promise<{ food: unknown }> => ({ food: [] }))
 const mockGetFragmentData = mock(() => ({ foodData: [] as unknown[] }))
 
 mock.module(`${SRC_ROOT}localization/i18n.ts`, () => ({

--- a/src/utils/tests/food-utils.test.ts
+++ b/src/utils/tests/food-utils.test.ts
@@ -8,7 +8,9 @@ const platform = { OS: 'web' as 'web' | 'ios' | 'android' }
 const shareMock = mock(async () => {})
 const copyToClipboardMock = mock(async () => {})
 const trackEventMock = mock(() => {})
-const mockGetFoodPlan = mock(async (): Promise<{ food: unknown }> => ({ food: [] }))
+const mockGetFoodPlan = mock(
+	async (): Promise<{ food: unknown }> => ({ food: [] })
+)
 const mockGetFragmentData = mock(() => ({ foodData: [] as unknown[] }))
 
 mock.module(`${SRC_ROOT}localization/i18n.ts`, () => ({


### PR DESCRIPTION
## Summary

- Adds **34 new unit tests** across `date-utils`, `food-utils`, and `calendar-utils`
- Raises tracked line coverage from **85% → 95%** (`bun run test:coverage`)
- Brings `date-utils`, `food-utils`, and `calendar-utils` to ~100% line coverage

Closes #342

## Changes

### `date-utils.test.ts` (+23 tests)
Friendly formatters and relative time helpers: `formatFriendlyDate*`, `formatNearDate`, `getFriendlyWeek`, `formatDay`, `formatFriendlyRelativeTime`, `formatRelativeMinutes`, etc.

### `food-utils.test.ts` (+4 tests)
- `loadFoodEntries` — weekday mapping, static meal filtering, `includeStatic`
- `shareMeal` — Aptabase tracking + web clipboard / native share sheet

### `calendar-utils.test.ts` (+7 tests)
- `loadExamList` — API mapping, `modus: '2'` filter, aids deduplication
- `convertCalendarToWeekViewEvents` — all-day vs timed events
- `getNextReRegistrationEvent` — next upcoming rereg event
- Exam vs calendar tie-breaker in `selectCalendarCardEvents`

## Coverage

| File | Before | After |
|------|--------|-------|
| **Overall** | 85.05% | **95.32%** |
| `date-utils.ts` | 50.59% | **99.59%** |
| `food-utils.ts` | 58.62% | **100%** |
| `calendar-utils.ts` | 65.77% | **98.60%** |

## Test plan

- [x] `bun test`
- [x] `bun run test:coverage`
- [x] `bun tsc --noEmit`
- [ ] CI passes (Codecov upload)