### PR TITLE
fix: gate ErrorView analytics on consent and move tracking out of render

### DIFF
--- a/src/app/[...unmatched].tsx
+++ b/src/app/[...unmatched].tsx
@@ -4,6 +4,7 @@ import type React from 'react'
 import { useEffect, useLayoutEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import ErrorView from '@/components/Error/error-view'
+import { useSessionStore } from '@/hooks/useSessionStore'
 
 export default function Unmatched(): React.JSX.Element {
 	const navigation = useNavigation()
@@ -11,10 +12,14 @@ export default function Unmatched(): React.JSX.Element {
 	const pathname =
 		cleanedPathname.charAt(0).toUpperCase() + cleanedPathname.slice(1)
 	const { t } = useTranslation('navigation')
+	const analyticsInitialized = useSessionStore(
+		(state) => state.analyticsInitialized
+	)
 
 	useEffect(() => {
+		if (!analyticsInitialized) return
 		trackEvent('Unmatched', { pathname })
-	}, [pathname])
+	}, [analyticsInitialized, pathname])
 
 	useLayoutEffect(() => {
 		navigation.setOptions({

--- a/src/components/Error/crash-view.tsx
+++ b/src/components/Error/crash-view.tsx
@@ -1,9 +1,11 @@
 import { trackEvent } from '@aptabase/react-native'
 import { type ErrorBoundaryProps, usePathname } from 'expo-router'
 import type React from 'react'
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Pressable, Text, View } from 'react-native'
 import { createStyleSheet, useStyles } from 'react-native-unistyles'
+import { useSessionStore } from '@/hooks/useSessionStore'
 
 import LogoTextSVG from '../Flow/svgs/logoText'
 import PlatformIcon from '../Universal/Icon'
@@ -32,11 +34,18 @@ export default function CrashView({
 	const { styles, theme } = useStyles(stylesheet)
 	const { t } = useTranslation('common')
 	const path = usePathname()
-	trackEvent('ErrorView', {
-		title: error.message,
-		path,
-		crash: true
-	})
+	const analyticsInitialized = useSessionStore(
+		(state) => state.analyticsInitialized
+	)
+
+	useEffect(() => {
+		if (!analyticsInitialized) return
+		trackEvent('ErrorView', {
+			title: error.message,
+			path,
+			crash: true
+		})
+	}, [analyticsInitialized, error.message, path])
 
 	const handlePress = (): void => {
 		retry().catch((error) => {

--- a/src/components/Error/error-view.tsx
+++ b/src/components/Error/error-view.tsx
@@ -1,6 +1,7 @@
 import { trackEvent } from '@aptabase/react-native'
 import { router, usePathname } from 'expo-router'
 import type React from 'react'
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
 	Platform,
@@ -12,6 +13,7 @@ import {
 } from 'react-native'
 import Animated, { FadeIn } from 'react-native-reanimated'
 import { createStyleSheet, useStyles } from 'react-native-unistyles'
+import { useSessionStore } from '@/hooks/useSessionStore'
 import type { MaterialIcon } from '@/types/material-icons'
 import {
 	guestError,
@@ -54,6 +56,9 @@ export default function ErrorView({
 	const { styles } = useStyles(stylesheet)
 	const { t } = useTranslation('common')
 	const path = usePathname()
+	const analyticsInitialized = useSessionStore(
+		(state) => state.analyticsInitialized
+	)
 
 	const getIconIos = (): string => {
 		switch (title) {
@@ -89,13 +94,15 @@ export default function ErrorView({
 		) && isCritical
 
 	const showBox = !inModal && shouldTrack
-	if (shouldTrack) {
+
+	useEffect(() => {
+		if (!analyticsInitialized || !shouldTrack) return
 		trackEvent('ErrorView', {
 			title,
 			path,
 			crash: false
 		})
-	}
+	}, [analyticsInitialized, shouldTrack, title, path])
 
 	const getTitle = (): string => {
 		switch (title) {

--- a/src/components/Map/search-results.tsx
+++ b/src/components/Map/search-results.tsx
@@ -8,6 +8,7 @@ import { Alert, Platform, SectionList, Text } from 'react-native'
 import { createStyleSheet, useStyles } from 'react-native-unistyles'
 import { MapContext } from '@/contexts/map'
 import { usePreferencesStore } from '@/hooks/usePreferencesStore'
+import { useSessionStore } from '@/hooks/useSessionStore'
 import type { SearchResult } from '@/types/map'
 
 import Divider from '../Universal/Divider'
@@ -31,6 +32,9 @@ const SearchResults: React.FC<SearchResultsProps> = ({
 	const addUnlockedAppIcon = usePreferencesStore(
 		(state) => state.addUnlockedAppIcon
 	)
+	const analyticsInitialized = useSessionStore(
+		(state) => state.analyticsInitialized
+	)
 	useEffect(() => {
 		if (
 			localSearch.toLocaleLowerCase() === 'neuland' &&
@@ -51,7 +55,9 @@ const SearchResults: React.FC<SearchResultsProps> = ({
 				],
 				{ cancelable: false }
 			)
-			trackEvent('EasterEgg', { easterEgg: 'mapSearchNeuland' })
+			if (analyticsInitialized) {
+				trackEvent('EasterEgg', { easterEgg: 'mapSearchNeuland' })
+			}
 
 			addUnlockedAppIcon('retro')
 		}


### PR DESCRIPTION
Closes #344.

We had a few spots where Aptabase was getting events it shouldn't — either before the user opted in, or repeatedly on every re-render.

**What changed**

- `crash-view` and `error-view` now track in a `useEffect` behind `analyticsInitialized`, instead of firing from the render body. Pull-to-refresh on an error screen no longer spams duplicate `ErrorView` events.
- The unmatched-route screen and the map "neuland" easter egg got the same consent gate. The easter egg alert and icon unlock behave exactly as before; we just skip the analytics call when tracking isn't initialized yet.

**How to verify**

1. Opt out of analytics in onboarding → trigger an error → no events in Aptabase.
2. Opt in → same error → one `ErrorView` event.
3. Pull to refresh on an error screen → still one event, not N.
4. Hit a bad URL → `Unmatched` fires once after consent.
5. iOS map search easter egg still unlocks the retro icon.

`tsc`, biome, and all 159 unit tests pass locally.