### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -496,3 +496,29 @@ Android uses Material Symbols (custom font), Web uses `lucide-react-native`.
 - Prefer changing Expo config / plugins over editing `ios/` or `android/` directly. Touch
   native projects only when the required change cannot be expressed in config.
 - For larger architectural changes, open a draft PR early and link the related issue.
+
+---
+
+## Cursor Cloud specific instructions
+
+Dependencies (`bun install`) are refreshed automatically by the cloud startup script, so
+you normally don't need to reinstall them. Notes that are not obvious from the commands above:
+
+- **Only the web target runs in the cloud VM.** `bun ios` / `bun android` need a device,
+  simulator, or native build and cannot run here. To run/test the app, use `bun web`
+  (Expo web dev server on `http://localhost:3000`). The first Metro bundle takes ~25s;
+  wait for `Bundled … node_modules/expo-router/entry.js` before opening the page.
+- **A `.env.local` file is required to run the app.** Copy it from `.env.local.example`
+  (`cp .env.local.example .env.local`). The example values are real public endpoints:
+  the Neuland GraphQL endpoint works (so cafeteria/announcements load), but
+  `EXPO_PUBLIC_THI_API_KEY` is a placeholder, so THI-authenticated features
+  (timetable, grades, profile) won't work without real credentials. The file is
+  git-ignored and persists in the VM snapshot, so it usually already exists.
+- **Test public features as a guest.** The onboarding screen has a "continue as guest"
+  link below the sign-in form. Guest mode unlocks public data (dashboard events,
+  cafeteria menu). The Map tab may show a load error and Timetable/Calendar/Grades
+  show "Sign in required" without a real THI login — that is expected, not a regression.
+- Standard checks match CI and all pass locally: `bun lint`, `bun tsc --noEmit`,
+  `bun i18n:check`, `bun test --ci`. Run these before pushing (see the Commands section).
+- Git LFS assets (images/fonts/SVGs) are pulled on checkout; if an asset looks missing or
+  is a tiny text pointer, run `git lfs pull`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Neuland Next development environment for Cursor Cloud agents, and documents the non-obvious caveats in `AGENTS.md`.

The only code change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. No application code was modified.

## Environment setup

- Installed **Bun** (package manager) and pulled **Git LFS** assets.
- `bun install --frozen-lockfile` — 1218 packages, clean.
- Created a git-ignored `.env.local` from `.env.local.example` (public endpoints; THI key is a placeholder, so authenticated features need real credentials).
- **Update script** (runs on VM startup): `bun install`.

## Verification

CI-equivalent checks all pass:

- ✅ `bun lint`
- ✅ `bun tsc --noEmit`
- ✅ `bun i18n:check`
- ✅ `bun test --ci` (159 tests pass)

Ran the web app (`bun web`, `http://localhost:3000`) and completed a hello-world flow as a guest: entered the app, loaded the dashboard, and loaded the live cafeteria menu from the Neuland GraphQL API.

[neuland_next_web_guest_cafeteria_demo.mp4](https://cursor.com/agents/bc-c82786de-224d-4079-81e6-f87617de44ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fneuland_next_web_guest_cafeteria_demo.mp4)

[Dashboard home](https://cursor.com/agents/bc-c82786de-224d-4079-81e6-f87617de44ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_home.webp)
[Cafeteria menu](https://cursor.com/agents/bc-c82786de-224d-4079-81e6-f87617de44ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcafeteria_menu.webp)

## Notes for future cloud agents (captured in AGENTS.md)

- Only the **web** target runs in the cloud VM; `bun ios` / `bun android` need a device/native build.
- `.env.local` is required to run the app (copy from `.env.local.example`).
- Test public features as a **guest**; Map errors and "Sign in required" on Timetable/Calendar/Grades are expected without a real THI login.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c82786de-224d-4079-81e6-f87617de44ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c82786de-224d-4079-81e6-f87617de44ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

