### PR TITLE
docs: add Cursor Cloud setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -496,3 +496,30 @@ Android uses Material Symbols (custom font), Web uses `lucide-react-native`.
 - Prefer changing Expo config / plugins over editing `ios/` or `android/` directly. Touch
   native projects only when the required change cannot be expressed in config.
 - For larger architectural changes, open a draft PR early and link the related issue.
+
+---
+
+## Cursor Cloud specific instructions
+
+The cloud VM has no iOS Simulator or Android emulator, so the **web target is the only
+runnable build** here. Use it for any manual verification.
+
+- **Run the app**: `bun web` (Expo web on port 3000, see the `web` script). Metro bundles
+  on first request; expect `Web Bundled … (… modules)` in the log, then `http://localhost:3000`
+  serves HTTP 200. The app opens in **guest mode** — no login is required to exercise core
+  public features (dashboard cards, cafeteria/`Food` menu, campus `Map`, theme switching),
+  which pull from public THI/Neuland endpoints.
+- **Git LFS is required before bundling.** Images/fonts/SVGs are stored in Git LFS. If the
+  checkout left them as pointer files, Metro web bundling fails with
+  `TypeError: unsupported file type: undefined (file: …/src/assets/…png)`. Run `git lfs pull`
+  to materialize them (this is in the startup update script, but re-run it if you hit that
+  error). Do not "fix" a supposedly corrupt/missing asset until you've confirmed LFS objects
+  are present.
+- **No `.env.local` is needed** to run the web app — the public API endpoints have code
+  defaults (see `src/api/anonymous-api.ts` / `neuland-api.ts`). Only create `.env.local`
+  (from `.env.local.example`) if you need to override endpoints or enable analytics.
+- **Chrome in the VM is memory-constrained.** It can show transient "Aw, Snap!" (Error
+  code 4) crashes, especially right after a hard page reload. The app itself is fine —
+  prefer in-app tab navigation over reloading the page when testing.
+- Standard checks match CI and are already documented under "Commands":
+  `bun test --ci`, `bun lint` (Biome), `bun tsc --noEmit`, `bun i18n:check`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for Neuland Next in the Cursor Cloud VM, and documents the non-obvious gotchas for future cloud agents.

The only code change is an additive `## Cursor Cloud specific instructions` section in `AGENTS.md`. No application code was modified.

## What was verified

The web target is the only runnable build in the cloud VM (no iOS/Android simulators). It runs in guest mode against public APIs.

| Check | Command | Result |
| --- | --- | --- |
| Unit tests | `bun test --ci` | 159 pass / 0 fail |
| Lint | `bun lint` (Biome) | clean (320 files) |
| Types | `bun tsc --noEmit` | clean |
| i18n | `bun i18n:check` | no missing/invalid keys |
| Run (web) | `bun web` → http://localhost:3000 | HTTP 200, bundles OK |

## Key gotcha documented

Git LFS assets must be materialized (`git lfs pull`) before Metro web bundling, otherwise it fails with `unsupported file type: undefined` on PNG assets. This is now in both the startup update script and AGENTS.md.

## Hello-world demo

Guest-mode walkthrough: dashboard → cafeteria menu loads → campus map renders → theme switched (dark → light) live.

[neuland_next_web_clean_demo.mp4](https://cursor.com/agents/bc-2b2e314e-d059-4fc6-ad8b-0cb449ebabcf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fneuland_next_web_clean_demo.mp4)

[Cafeteria menu loaded](https://cursor.com/agents/bc-2b2e314e-d059-4fc6-ad8b-0cb449ebabcf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffood_menu_clean.webp)
[Campus map rendered](https://cursor.com/agents/bc-2b2e314e-d059-4fc6-ad8b-0cb449ebabcf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcampus_map_clean.webp)
[Theme switched to light](https://cursor.com/agents/bc-2b2e314e-d059-4fc6-ad8b-0cb449ebabcf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftheme_switched.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b2e314e-d059-4fc6-ad8b-0cb449ebabcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b2e314e-d059-4fc6-ad8b-0cb449ebabcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

