### PR TITLE
feat(ios): add wallet pass-type entitlement to expo config

### DIFF
--- a/app.config.json
+++ b/app.config.json
@@ -25,6 +25,11 @@
 				"applinks:web.neuland.app",
 				"applinks:dev.neuland.app"
 			],
+			"entitlements": {
+				"com.apple.developer.pass-type-identifiers": [
+					"$(TeamIdentifierPrefix)pass.member.neuland.app"
+				]
+			},
 			"config": {
 				"usesNonExemptEncryption": false
 			},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `com.apple.developer.pass-type-identifiers` to `expo.ios.entitlements` in `app.config.json` so `expo prebuild` auto-generates the Apple Wallet entitlement required by `react-native-wallet-manager`.

Part of the iOS dynamic prebuild migration ([#398](https://github.com/neuland-ingolstadt/neuland.app-native/issues/398)); closes [#400](https://github.com/neuland-ingolstadt/neuland.app-native/issues/400).

**Targets parent branch:** `cursor/ios-dynamic-prebuild-22fa` (not `main`).

## Verification

Clean local prebuild (no committed `ios/` used):

```bash
git lfs pull
rm -rf ios
bunx expo prebuild -p ios --no-install
```

Generated `ios/NeulandNext/NeulandNext.entitlements` includes the pass-type identifier.

## Checklist

- [x] Verified with clean local `expo prebuild -p ios`
- [ ] Tested on iOS device (Wallet add-pass flow)
- [ ] Not applicable: Android / Web
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed2b2-1f3a-7e3c-8452-60e1f7c622fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed2b2-1f3a-7e3c-8452-60e1f7c622fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

