### PR TITLE
feat(ios): inject xcode 26 fmt workaround via config plugin

### DIFF
--- a/app.config.json
+++ b/app.config.json
@@ -189,6 +189,7 @@
 				"./src/assets/android/check.xml"
 			],
 			"./config/plugins/withIosCiArtifacts.js",
+			"./config/plugins/withXcode26FmtWorkaround.js",
 			"expo-font"
 		],
 		"extra": {

--- a/config/plugins/withXcode26FmtWorkaround.js
+++ b/config/plugins/withXcode26FmtWorkaround.js
@@ -1,0 +1,55 @@
+const { withPodfile } = require('expo/config-plugins')
+const { mergeContents } = require('@expo/config-plugins/build/utils/generateCode')
+
+const TAG = 'neuland:xcode26-fmt-workaround'
+
+const FMT_WORKAROUND = `      # https://github.com/expo/expo/issues/44229#issuecomment-4125779703
+      # Workaround for Xcode 26: newer Apple Clang breaks consteval in fmt 11.0.2.
+      # TODO: Remove after upgrading to Expo 55 (or newer)
+      # fix from: https://github.com/expo/expo/issues/44229#issuecomment-4134299446
+      fmt_base = File.join(installer.sandbox.root, 'fmt', 'include', 'fmt', 'base.h')
+      xcode_version = \`xcodebuild -version\`.match(/Xcode ([\\d.]+)/)[1] rescue nil
+
+      if File.exist?(fmt_base) && (xcode_version.nil? || xcode_version.to_f >= 26.4)
+        content = File.read(fmt_base)
+        unless content.include?('Xcode 26 workaround')
+          patched = content.gsub(
+            /^(#elif defined\\(__cpp_consteval\\)\\n#  define FMT_USE_CONSTEVAL) 1/,
+            "// Xcode 26 workaround: disable consteval\\n\\\\1 0"
+          )
+          if patched != content
+            File.chmod(0644, fmt_base)
+            File.write(fmt_base, patched)
+          else
+            Pod::UI.puts "[Podfile] Xcode 26.4 fmt workaround not applied: expected pattern not found in #{fmt_base}. The header may have changed; please update or remove this patch."
+          end
+        end
+      end`
+
+function applyXcode26FmtWorkaround(contents) {
+	const result = mergeContents({
+		tag: TAG,
+		src: contents,
+		newSrc: FMT_WORKAROUND,
+		anchor: /:ccache_enabled => ccache_enabled\?\(podfile_properties\),/,
+		offset: 2,
+		comment: '#'
+	})
+
+	if (result.didMerge || result.didClear) {
+		return result.contents
+	}
+
+	return contents
+}
+
+function withXcode26FmtWorkaround(expoConfig) {
+	return withPodfile(expoConfig, (modConfig) => {
+		modConfig.modResults.contents = applyXcode26FmtWorkaround(
+			modConfig.modResults.contents
+		)
+		return modConfig
+	})
+}
+
+module.exports = withXcode26FmtWorkaround


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `config/plugins/withXcode26FmtWorkaround.js` to inject the Xcode 26 `fmt` `consteval` Podfile patch during `expo prebuild`, matching the workaround already present in the committed `ios/Podfile`.

Part of the iOS dynamic prebuild migration ([#398](https://github.com/neuland-ingolstadt/neuland.app-native/issues/398)); closes [#401](https://github.com/neuland-ingolstadt/neuland.app-native/issues/401).

**Targets parent branch:** `cursor/ios-dynamic-prebuild-22fa` (not `main`).

## Changes

- `config/plugins/withXcode26FmtWorkaround.js` — uses `withPodfile` + `mergeContents`
- `app.config.json` — registers the plugin
- `ios/Podfile` — unchanged for now (dual location during migration)

## Verification

Clean `expo prebuild -p ios` regenerates the `# @generated begin neuland:xcode26-fmt-workaround` block in `ios/Podfile`.

## Checklist

- [x] Verified workaround block is regenerated by clean prebuild
- [ ] Verified `pod install` on macOS with Xcode 26.4+
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed2b2-1f3a-7e3c-8452-60e1f7c622fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed2b2-1f3a-7e3c-8452-60e1f7c622fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

