### PR TITLE
feat(ios): sync tuned Default.icon metadata into src/assets

### DIFF
--- a/src/assets/appIcons/Default.icon/icon.json
+++ b/src/assets/appIcons/Default.icon/icon.json
@@ -1,8 +1,39 @@
 {
 	"color-space-for-untagged-svg-colors": "display-p3",
-	"fill": "automatic",
+	"fill-specializations": [
+		{
+			"value": "automatic"
+		},
+		{
+			"appearance": "dark",
+			"value": "automatic"
+		}
+	],
 	"groups": [
 		{
+			"blend-mode-specializations": [
+				{
+					"value": "plus-darker"
+				},
+				{
+					"appearance": "dark",
+					"value": "lighten"
+				},
+				{
+					"appearance": "tinted",
+					"value": "normal"
+				}
+			],
+			"blur-material-specializations": [
+				{
+					"value": null
+				},
+				{
+					"appearance": "dark",
+					"value": null
+				}
+			],
+			"hidden": false,
 			"layers": [
 				{
 					"blend-mode-specializations": [
@@ -50,14 +81,65 @@
 					}
 				}
 			],
-			"shadow": {
-				"kind": "neutral",
-				"opacity": 0.5
-			},
-			"translucency": {
-				"enabled": true,
-				"value": 0.5
-			}
+			"lighting-specializations": [
+				{
+					"value": "individual"
+				},
+				{
+					"appearance": "dark",
+					"value": "individual"
+				},
+				{
+					"appearance": "tinted",
+					"value": "individual"
+				}
+			],
+			"shadow-specializations": [
+				{
+					"value": {
+						"kind": "neutral",
+						"opacity": 0.5
+					}
+				},
+				{
+					"appearance": "dark",
+					"value": {
+						"kind": "neutral",
+						"opacity": 0.5
+					}
+				}
+			],
+			"specular-specializations": [
+				{
+					"value": true
+				},
+				{
+					"appearance": "dark",
+					"value": true
+				}
+			],
+			"translucency-specializations": [
+				{
+					"value": {
+						"enabled": true,
+						"value": 0.42
+					}
+				},
+				{
+					"appearance": "dark",
+					"value": {
+						"enabled": true,
+						"value": 0.3
+					}
+				},
+				{
+					"appearance": "tinted",
+					"value": {
+						"enabled": true,
+						"value": 0.45
+					}
+				}
+			]
 		}
 	],
 	"supported-platforms": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Syncs the production-tuned `Default.icon` liquid-glass metadata from the committed `ios/NeulandNext/Default.icon/icon.json` into `src/assets/appIcons/Default.icon/icon.json`.

`expo.ios.icon` already points at `src/assets/appIcons/Default.icon` — prebuild was using the simplified asset and would lose Xcode tuning (blur, lighting, translucency specializations).

Part of the iOS dynamic prebuild migration ([#398](https://github.com/neuland-ingolstadt/neuland.app-native/issues/398)); closes [#403](https://github.com/neuland-ingolstadt/neuland.app-native/issues/403).

**Targets parent branch:** `cursor/ios-dynamic-prebuild-22fa` (not `main`).

## Changes

- `src/assets/appIcons/Default.icon/icon.json` — matches production tuning from committed `ios/`
- SVG unchanged (already identical)

## Verification

```bash
git lfs pull
rm -rf ios
bunx expo prebuild -p ios --no-install
diff -q src/assets/appIcons/Default.icon/icon.json ios/NeulandNext/Default.icon/icon.json
```

Prebuild output matches `src/assets` and includes tuned keys (`blur-material-specializations`, `lighting-specializations`, `translucency-specializations`).

## Checklist

- [x] Verified `Default.icon` is regenerated correctly by clean prebuild
- [ ] Visual check on device (light / dark / tinted appearances)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed2b2-1f3a-7e3c-8452-60e1f7c622fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed2b2-1f3a-7e3c-8452-60e1f7c622fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

