### PR TITLE
feat(ios): run git lfs pull and expo prebuild in Xcode Cloud CI

### DIFF
--- a/config/ios-artifacts/ci_scripts/ci_post_clone.sh
+++ b/config/ios-artifacts/ci_scripts/ci_post_clone.sh
@@ -25,6 +25,14 @@ bun install --frozen-lockfile --ignore-scripts
 npm install npm-license-crawler -g
 npx npm-license-crawler -onlyDirectDependencies -json src/data/licenses.json --exclude docs/
 
+echo "===== Pulling Git LFS assets ====="
+brew install git-lfs
+git lfs install --local 2>/dev/null || git lfs install
+git lfs pull
+
+echo "===== Running expo prebuild ====="
+bunx expo prebuild -p ios --no-install
+
 echo "===== Running pod install ====="
 cd ios
 pod install

--- a/config/ios-artifacts/ci_scripts/ci_post_clone.sh
+++ b/config/ios-artifacts/ci_scripts/ci_post_clone.sh
@@ -31,8 +31,4 @@ git lfs install --local 2>/dev/null || git lfs install
 git lfs pull
 
 echo "===== Running expo prebuild ====="
-bunx expo prebuild -p ios --no-install
-
-echo "===== Running pod install ====="
-cd ios
-pod install
+bunx expo prebuild -p ios

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -25,6 +25,14 @@ bun install --frozen-lockfile --ignore-scripts
 npm install npm-license-crawler -g
 npx npm-license-crawler -onlyDirectDependencies -json src/data/licenses.json --exclude docs/
 
+echo "===== Pulling Git LFS assets ====="
+brew install git-lfs
+git lfs install --local 2>/dev/null || git lfs install
+git lfs pull
+
+echo "===== Running expo prebuild ====="
+bunx expo prebuild -p ios --no-install
+
 echo "===== Running pod install ====="
 cd ios
 pod install

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -31,8 +31,4 @@ git lfs install --local 2>/dev/null || git lfs install
 git lfs pull
 
 echo "===== Running expo prebuild ====="
-bunx expo prebuild -p ios --no-install
-
-echo "===== Running pod install ====="
-cd ios
-pod install
+bunx expo prebuild -p ios


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Updates `ci_post_clone.sh` for Xcode Cloud to support dynamic iOS prebuild:

1. `brew install git-lfs` + `git lfs pull` — required for app icon assets before prebuild
2. `bunx expo prebuild -p ios` — generates `ios/` and runs `pod install` in one step

Part of the iOS dynamic prebuild migration ([#398](https://github.com/neuland-ingolstadt/neuland.app-native/issues/398)); closes [#404](https://github.com/neuland-ingolstadt/neuland.app-native/issues/404).

**Targets parent branch:** `cursor/ios-dynamic-prebuild-22fa` (not `main`).

## Changes

- `config/ios-artifacts/ci_scripts/ci_post_clone.sh` — source of truth
- `ios/ci_scripts/ci_post_clone.sh` — kept in sync (dual location during migration)

## Verification

- `expo prebuild -p ios` copies updated script from `config/ios-artifacts/` via `withIosCiArtifacts`
- Local `git lfs pull` + `expo prebuild -p ios` succeeds

## Checklist

- [x] Script updated in both `config/ios-artifacts/` and `ios/ci_scripts/`
- [x] Local prebuild confirms CI script is copied correctly
- [ ] Xcode Cloud build on next push to verify end-to-end
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed2b2-1f3a-7e3c-8452-60e1f7c622fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed2b2-1f3a-7e3c-8452-60e1f7c622fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

