### PR TITLE
fix(ios): bump react-native-nitro-modules for mmkv RecyclableView

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -75,7 +75,7 @@
         "react-native-draggable-flatlist": "^4.0.3",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-mmkv": "^4.1.1",
-        "react-native-nitro-modules": "^0.32.1",
+        "react-native-nitro-modules": "^0.35.0",
         "react-native-pager-view": "6.9.1",
         "react-native-reanimated": "3.19.1",
         "react-native-safe-area-context": "~5.6.2",
@@ -1864,7 +1864,7 @@
 
     "react-native-mmkv": ["react-native-mmkv@4.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-nitro-modules": "*" } }, "sha512-APyGGaaHtayVgT18dBM8QGGZKr9pGfSTiBwbbPNzhGGfJQSU7awLGRGq879OqYl31HmVks9hOBLCs+qfgacRZg=="],
 
-    "react-native-nitro-modules": ["react-native-nitro-modules@0.32.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-N1F0EgoKEQJDs0clAGZTauXauxBYUN8y8QLEyeBy3WJhXUlzuldllah4CqRu0WVxZGA+5pTcxXsPeXAHDa6Wag=="],
+    "react-native-nitro-modules": ["react-native-nitro-modules@0.35.9", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-yCO6eJ85SPPUo4a4an7H5oj6wPCSIT72fbjr5WZ/20n6zswaJ2gNNpnWtg2We0AZwkAOjSqkOJ0Vjc05p6kGiA=="],
 
     "react-native-pager-view": ["react-native-pager-view@6.9.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-uUT0MMMbNtoSbxe9pRvdJJKEi9snjuJ3fXlZhG8F2vVMOBJVt/AFtqMPUHu9yMflmqOr08PewKzj9EPl/Yj+Gw=="],
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 		"react-native-draggable-flatlist": "^4.0.3",
 		"react-native-gesture-handler": "~2.28.0",
 		"react-native-mmkv": "^4.1.1",
-		"react-native-nitro-modules": "^0.32.1",
+		"react-native-nitro-modules": "^0.35.0",
 		"react-native-pager-view": "6.9.1",
 		"react-native-reanimated": "3.19.1",
 		"react-native-safe-area-context": "~5.6.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes iOS build failure when running `bun ios` / `expo run:ios`:

```
cannot find type 'RecyclableView' in scope
  (NitroMmkvAutolinking.swift)
```

`react-native-mmkv` 4.1.2+ (resolved from `^4.1.1`) generates Swift autolinking code that references `RecyclableView`, but that protocol was only added in `react-native-nitro-modules` 0.33+. The project had `^0.32.1`.

### Change

Bump `react-native-nitro-modules` from `^0.32.1` to `^0.35.0`.

### After merging / locally

```bash
bun install
cd ios && pod install && cd ..
bun ios
```

## Verification

- [x] `bun tsc --noEmit`
- [x] `bun lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed2b2-1f3a-7e3c-8452-60e1f7c622fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed2b2-1f3a-7e3c-8452-60e1f7c622fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

