### PR TITLE
fix: prevent reopen crash and update react-native-mmkv to 4.3.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
         "react-native-device-info": "^14.1.1",
         "react-native-draggable-flatlist": "^4.0.3",
         "react-native-gesture-handler": "~2.28.0",
-        "react-native-mmkv": "^4.1.1",
+        "react-native-mmkv": "4.3.1",
         "react-native-nitro-modules": "^0.35.0",
         "react-native-pager-view": "6.9.1",
         "react-native-reanimated": "3.19.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"react-native-device-info": "^14.1.1",
 		"react-native-draggable-flatlist": "^4.0.3",
 		"react-native-gesture-handler": "~2.28.0",
-		"react-native-mmkv": "^4.1.1",
+		"react-native-mmkv": "4.3.1",
 		"react-native-nitro-modules": "^0.35.0",
 		"react-native-pager-view": "6.9.1",
 		"react-native-reanimated": "3.19.1",

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -4,7 +4,7 @@ import { router } from 'expo-router'
 import Head from 'expo-router/head'
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Dimensions, LayoutAnimation, Platform, View } from 'react-native'
+import { Dimensions, Platform, View } from 'react-native'
 import { createStyleSheet, useStyles } from 'react-native-unistyles'
 import { getFragmentData } from '@/__generated__/gql'
 import { AnnouncementFieldsFragmentDoc } from '@/__generated__/gql/graphql'
@@ -75,10 +75,6 @@ const HomeScreen = memo(function HomeScreen() {
 		staleTime: 1000 * 60 * 10, // 10 minutes
 		gcTime: 1000 * 60 * 60 * 24 * 7 // 7 days
 	})
-
-	useEffect(() => {
-		LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
-	}, [shownDashboardEntries])
 
 	useEffect(() => {
 		const handleOrientationChange = (): void => {

--- a/src/components/Cards/announcement-card.tsx
+++ b/src/components/Cards/announcement-card.tsx
@@ -1,6 +1,6 @@
 import { trackEvent } from '@aptabase/react-native'
 import type React from 'react'
-import { memo, use, useCallback, useMemo } from 'react'
+import { memo, use, useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
 	Image,
@@ -13,6 +13,7 @@ import {
 	View
 } from 'react-native'
 import Animated, {
+	cancelAnimation,
 	interpolate,
 	useAnimatedStyle,
 	useSharedValue,
@@ -45,6 +46,13 @@ const AnnouncementCard = ({
 
 	const scale = useSharedValue(1)
 	const rotation = useSharedValue(0)
+
+	useEffect(() => {
+		return () => {
+			cancelAnimation(scale)
+			cancelAnimation(rotation)
+		}
+	}, [rotation, scale])
 
 	const animatedIconStyle = useAnimatedStyle(() => {
 		return {

--- a/src/components/Cards/base-card.tsx
+++ b/src/components/Cards/base-card.tsx
@@ -1,10 +1,11 @@
 import { type Href, Link, type RelativePathString, router } from 'expo-router'
 import type React from 'react'
-import { use } from 'react'
+import { use, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Platform, Pressable, StyleSheet, Text, View } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import Animated, {
+	cancelAnimation,
 	interpolate,
 	useAnimatedStyle,
 	useSharedValue,
@@ -38,6 +39,13 @@ const BaseCard = ({
 
 	const scale = useSharedValue(1)
 	const rotation = useSharedValue(0)
+
+	useEffect(() => {
+		return () => {
+			cancelAnimation(scale)
+			cancelAnimation(rotation)
+		}
+	}, [rotation, scale])
 
 	const animatedIconStyle = useAnimatedStyle(() => {
 		return {

--- a/src/components/Flow/svgs/animated-text.tsx
+++ b/src/components/Flow/svgs/animated-text.tsx
@@ -33,6 +33,8 @@ const AnimatedText = ({
 }): React.JSX.Element => {
 	const colorValue = useSharedValue(0)
 	const { theme } = useStyles()
+	const textColor = theme.colors.text
+	const secondaryLabelColor = theme.colors.labelSecondaryColor
 	useEffect(() => {
 		if (!disabled) {
 			colorValue.value = withRepeat(
@@ -52,12 +54,12 @@ const AnimatedText = ({
 		const interpolatedColor = interpolateColor(
 			colorValue.value,
 			[0, 1],
-			[theme.colors.text, theme.colors.labelSecondaryColor] // Interpolating between text and secondary label colors
+			[textColor, secondaryLabelColor]
 		)
 		return {
 			color: interpolatedColor
 		}
-	})
+	}, [secondaryLabelColor, textColor])
 
 	return (
 		<Animated.Text style={[animatedStyle, textStyles]}>{text}</Animated.Text>

--- a/src/components/Splash.tsx
+++ b/src/components/Splash.tsx
@@ -1,6 +1,6 @@
 import * as SplashScreen from 'expo-splash-screen'
 import type React from 'react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Platform, StyleSheet, View, type ViewStyle } from 'react-native'
 import Animated, {
 	Easing,
@@ -57,9 +57,14 @@ export function Splash({ isReady, children }: React.PropsWithChildren<Props>) {
 
 	const intro = useSharedValue(0)
 	const introBackground = useSharedValue(0)
+	const isMountedRef = useRef(true)
 
 	useEffect(() => {
 		setLoaded(true)
+
+		return () => {
+			isMountedRef.current = false
+		}
 	}, [])
 
 	const logoSize = 190
@@ -68,27 +73,45 @@ export function Splash({ isReady, children }: React.PropsWithChildren<Props>) {
 	const iosXShift = 20
 	const iosMarginStyle: ViewStyle =
 		Platform.OS === 'ios' ? { marginLeft: -iosXShift / 2 } : {}
+	const contrastColor = theme.colors.contrast
 
-	const animatedLogoStyle = useAnimatedStyle(() => ({
-		transform: showSplashScreen
-			? [
-					{
-						scale: interpolate(
-							intro.value,
-							[0, 0.2, 0.4, 1],
-							[1, 1, 0.8, 10],
-							'clamp'
-						)
-					}
-				]
-			: [],
-		opacity: interpolate(intro.value, [0, 0.7, 0.8, 1], [1, 1, 0.4, 0], 'clamp')
-	}))
+	const hideSplashFromWorklet = () => {
+		if (isMountedRef.current) {
+			setHideSplash(true)
+		}
+	}
 
-	const animatedBackgroundStyle = useAnimatedStyle(() => ({
-		backgroundColor: theme.colors.contrast,
-		opacity: interpolate(introBackground.value, [0, 1], [1, 0], 'clamp')
-	}))
+	const animatedLogoStyle = useAnimatedStyle(
+		() => ({
+			transform: showSplashScreen
+				? [
+						{
+							scale: interpolate(
+								intro.value,
+								[0, 0.2, 0.4, 1],
+								[1, 1, 0.8, 10],
+								'clamp'
+							)
+						}
+					]
+				: [],
+			opacity: interpolate(
+				intro.value,
+				[0, 0.7, 0.8, 1],
+				[1, 1, 0.4, 0],
+				'clamp'
+			)
+		}),
+		[showSplashScreen]
+	)
+
+	const animatedBackgroundStyle = useAnimatedStyle(
+		() => ({
+			backgroundColor: contrastColor,
+			opacity: interpolate(introBackground.value, [0, 1], [1, 0], 'clamp')
+		}),
+		[contrastColor]
+	)
 
 	const animateSplashWithTransformation = () => {
 		intro.value = withTiming(0.2, { duration: 100 }, () => {
@@ -98,7 +121,7 @@ export function Splash({ isReady, children }: React.PropsWithChildren<Props>) {
 					{ duration: 500, easing: Easing.out(Easing.exp) },
 					() => {
 						introBackground.value = withTiming(1, { duration: 200 }, () => {
-							runOnJS(setHideSplash)(true)
+							runOnJS(hideSplashFromWorklet)()
 						})
 					}
 				)

--- a/src/components/Universal/pulsing-dot.tsx
+++ b/src/components/Universal/pulsing-dot.tsx
@@ -1,6 +1,8 @@
 import type React from 'react'
+import { useEffect } from 'react'
 import type { StyleProp, ViewStyle } from 'react-native'
 import Animated, {
+	cancelAnimation,
 	useAnimatedReaction,
 	useAnimatedStyle,
 	useSharedValue,
@@ -23,6 +25,12 @@ const PulsingDot = ({
 }: PulsingDotProps): React.JSX.Element => {
 	const pulseOpacity = useSharedValue(minOpacity)
 	const isActive = useSharedValue(true)
+
+	useEffect(() => {
+		return () => {
+			cancelAnimation(pulseOpacity)
+		}
+	}, [pulseOpacity])
 
 	useAnimatedReaction(
 		() => isActive.value,

--- a/src/contexts/dashboard.ts
+++ b/src/contexts/dashboard.ts
@@ -1,3 +1,4 @@
+import { useIsRestoring } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo } from 'react'
 import { useMMKVBoolean, useMMKVObject } from 'react-native-mmkv'
 import { AllCards, type Card } from '@/components/all-cards'
@@ -15,22 +16,27 @@ interface DashboardOrder {
 
 export function isCardEnabled(
 	card: Pick<Card, 'featureFlag'>,
-	flags: FeatureFlagState
+	flags: FeatureFlagState,
+	options?: { skipFeatureFlagCheck?: boolean }
 ): boolean {
-	if (card.featureFlag == null) {
+	if (card.featureFlag == null || options?.skipFeatureFlagCheck === true) {
 		return true
 	}
 
 	return flags[card.featureFlag] === true
 }
 
-function isCardKeyEnabled(cardKey: string, flags: FeatureFlagState): boolean {
+function isCardKeyEnabled(
+	cardKey: string,
+	flags: FeatureFlagState,
+	options?: { skipFeatureFlagCheck?: boolean }
+): boolean {
 	const card = AllCards.find((entry) => entry.key === cardKey)
 	if (card == null) {
 		return false
 	}
 
-	return isCardEnabled(card, flags)
+	return isCardEnabled(card, flags, options)
 }
 
 export function getDefaultDashboardOrder(
@@ -129,6 +135,7 @@ export function useDashboard(): Dashboard {
 	)
 	const { userKind = USER_GUEST } = useUserKind()
 	const flags = useFeatureFlags()
+	const isRestoring = useIsRestoring()
 
 	const defaultEntries = useMemo(
 		() => getDefaultDashboardOrder(userKind, flags),
@@ -166,7 +173,7 @@ export function useDashboard(): Dashboard {
 	])
 
 	useEffect(() => {
-		if (shownDashboardEntries == null) {
+		if (isRestoring || shownDashboardEntries == null) {
 			return
 		}
 
@@ -179,17 +186,24 @@ export function useDashboard(): Dashboard {
 		if (!arraysEqual(merged, shownDashboardEntries)) {
 			setShownDashboardEntries(merged)
 		}
-	}, [shownDashboardEntries, userKind, flags, setShownDashboardEntries])
+	}, [
+		isRestoring,
+		shownDashboardEntries,
+		userKind,
+		flags,
+		setShownDashboardEntries
+	])
 
 	const normalizedShownEntries = useMemo(() => {
 		const fallback = defaultEntries.shown
 		const shownEntries = shownDashboardEntries ?? fallback
 		const knownCardKeys = new Set(AllCards.map((card) => card.key))
+		const flagOptions = isRestoring ? { skipFeatureFlagCheck: true } : undefined
 
 		return shownEntries
 			.filter((key) => knownCardKeys.has(key))
-			.filter((key) => isCardKeyEnabled(key, flags))
-	}, [shownDashboardEntries, defaultEntries.shown, flags])
+			.filter((key) => isCardKeyEnabled(key, flags, flagOptions))
+	}, [shownDashboardEntries, defaultEntries.shown, flags, isRestoring])
 
 	const entries = useMemo(
 		() =>

--- a/src/hooks/usePreferenceTracking.ts
+++ b/src/hooks/usePreferenceTracking.ts
@@ -1,4 +1,5 @@
 import { trackEvent } from '@aptabase/react-native'
+import { useIsRestoring } from '@tanstack/react-query'
 import { useSegments } from 'expo-router'
 import { useEffect } from 'react'
 import { Platform } from 'react-native'
@@ -29,6 +30,7 @@ export function usePreferenceTracking(): void {
 	const isNeulandMember = useMemberStore((state) => !!state.idToken)
 	const userKind = useUserKind()
 	const dashboard = useDashboard()
+	const isRestoring = useIsRestoring()
 
 	useEffect(() => {
 		if (!analyticsInitialized || !Array.isArray(segments)) return
@@ -82,7 +84,7 @@ export function usePreferenceTracking(): void {
 	}, [selectedRestaurants, analyticsInitialized])
 
 	useEffect(() => {
-		if (!analyticsInitialized) return
+		if (!analyticsInitialized || isRestoring) return
 		const entries: Record<string, string> = {}
 		dashboard.shownDashboardEntries.forEach((entry, index) => {
 			if (entry !== undefined) {
@@ -92,7 +94,7 @@ export function usePreferenceTracking(): void {
 		if (Object.keys(entries).length > 0) {
 			trackEvent('Dashboard', entries)
 		}
-	}, [dashboard.shownDashboardEntries, analyticsInitialized])
+	}, [dashboard.shownDashboardEntries, analyticsInitialized, isRestoring])
 
 	useEffect(() => {
 		if (!analyticsInitialized) return


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `react-native-mmkv` to `4.3.1` and fixes an intermittent iOS crash on app reopen (especially after Flipt feature-flag changes).

## Crash analysis (TestFlight 0.16.0, iOS 26.5)

**Signal:** `EXC_CRASH (SIGABRT)` → Hermes `throwPendingError()` inside Reanimated's UI scheduler (`scheduleOnUI` → `runGuarded`).

**Timing:** Crash ~520 ms after launch — matches splash animation + dashboard hydration window.

**Root cause (two interacting issues):**

1. **Unsafe Reanimated worklets** — `Splash.tsx` read `theme.colors.contrast` inside `useAnimatedStyle`. Unistyles theme objects are JS-thread proxies; accessing them from the UI worklet can throw and abort via Hermes. Same pattern existed in `animated-text.tsx`.

2. **Feature-flag hydration race** — Flags are cached in the React Query → MMKV persist layer (`query-client-storage`). On cold start, `PersistQueryClientProvider` restores asynchronously (`isRestoring=true` on first render). `FeatureFlagsProvider` treated missing data as `false`, so flag-gated dashboard cards (e.g. `thiEvents`) were filtered out, then re-added after MMKV hydration — or removed again after a Flipt refetch. This caused rapid FlashList churn + `LayoutAnimation` while Reanimated press animations were still scheduled on the UI thread.

**Why flag changes made it worse:** Toggling a flag updates the persisted React Query cache. Reopen then produces a false → true → (maybe) false sequence as restore + refetch disagree, maximizing card mount/unmount during the startup animation window.

## Fixes

- **Splash.tsx:** Extract `contrastColor` primitive; pass `showSplashScreen` via `useAnimatedStyle` deps; guard `runOnJS` hide callback with mount ref
- **dashboard.ts:** Skip feature-flag filtering and merge effects while `useIsRestoring()` is true
- **base-card / announcement-card / pulsing-dot:** `cancelAnimation` on unmount
- **animated-text.tsx:** Same theme-color worklet fix as Splash

## Dependency update

- `react-native-mmkv`: `^4.1.1` → `4.3.1`
- `react-native-nitro-modules`: unchanged at `^0.35.0` (resolves to `0.35.9`, satisfies 0.35.0+ requirement)

## Verification

- `bun tsc --noEmit` — pass
- `bun lint` — pass
- `bun pkgs` — no MMKV/nitro mismatches (only pre-existing `typescript@6.0.3` vs `~5.9.2`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019edc59-51f6-756c-b2b9-d21bbe257ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019edc59-51f6-756c-b2b9-d21bbe257ab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

