### PR TITLE
fix: include dev dependencies before running licences in android workflows

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -34,7 +34,7 @@ jobs:
           bun-version: latest
 
       - name: Install project dependencies
-        run: bun install --frozen-lockfile --ignore-scripts -p
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Update license list
         run: bun run licences

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
           bun-version: latest
 
       - name: Install project dependencies
-        run: bun install --frozen-lockfile --ignore-scripts -p
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Update license list
         run: bun run licences


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📋 Description

- fixes Android/release workflow failures where `bun run licences` could not find `npm-license-crawler`
- removes the production-only install flag (`-p`) from the two Android build jobs that run `bun run licences`
- keeps the rest of the workflow unchanged

## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web
- [x] I’ve added or updated documentation (if needed)
- [x] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

- root cause: `npm-license-crawler` is in `devDependencies`, but `bun install ... -p` excludes it in workflow jobs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aec03755-0d98-4ad0-9038-ca8ae9e6bcaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aec03755-0d98-4ad0-9038-ca8ae9e6bcaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

