### PR TITLE
test: add unit tests for untested pure utils

### DIFF
--- a/src/utils/tests/animation-utils.test.ts
+++ b/src/utils/tests/animation-utils.test.ts
@@ -5,7 +5,8 @@ const randomizeColorMock = mock(() => {})
 const onBounceMock = mock(() => {})
 
 mock.module('react-native', () => ({
-	Platform: { OS: 'ios' }
+	Platform: { OS: 'ios' },
+	Linking: { openURL: async () => {} }
 }))
 
 mock.module('expo-haptics', () => ({

--- a/src/utils/tests/animation-utils.test.ts
+++ b/src/utils/tests/animation-utils.test.ts
@@ -1,0 +1,114 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test'
+
+const impactAsyncMock = mock(async () => {})
+const randomizeColorMock = mock(() => {})
+const onBounceMock = mock(() => {})
+
+mock.module('react-native', () => ({
+	Platform: { OS: 'ios' }
+}))
+
+mock.module('expo-haptics', () => ({
+	ImpactFeedbackStyle: { Light: 'light' },
+	impactAsync: impactAsyncMock
+}))
+
+mock.module('react-native-reanimated', () => ({
+	defineAnimation: <T>(_initial: T, factory: () => T) => factory(),
+	runOnJS: <T extends (...args: never[]) => unknown>(fn: T) => fn
+}))
+
+let animationUtils: typeof import('../animation-utils')
+
+beforeAll(async () => {
+	animationUtils = await import('../animation-utils')
+})
+
+describe('animation-utils', () => {
+	it('withBouncing - Should initialise state within the configured bounds', () => {
+		const animation = animationUtils.withBouncing(
+			40,
+			0,
+			100,
+			randomizeColorMock,
+			onBounceMock
+		)
+
+		expect(typeof animation).toBe('object')
+		if (typeof animation === 'number') {
+			throw new Error('Expected animation callbacks')
+		}
+
+		const state = {
+			current: 0,
+			lastTimestamp: 1000,
+			direction: -1
+		}
+
+		animation.onStart(state, 0, 2000)
+
+		expect(state.current).toBe(80)
+		expect(state.lastTimestamp).toBe(2000)
+		expect(state.direction).toBe(1)
+	})
+
+	it('withBouncing - Should reverse direction and trigger bounce handlers at the top bound', () => {
+		randomizeColorMock.mockReset()
+		onBounceMock.mockReset()
+		impactAsyncMock.mockReset()
+
+		const animation = animationUtils.withBouncing(
+			50,
+			0,
+			100,
+			randomizeColorMock,
+			onBounceMock
+		)
+
+		if (typeof animation === 'number') {
+			throw new Error('Expected animation callbacks')
+		}
+
+		const state = {
+			current: 95,
+			lastTimestamp: 0,
+			direction: 1
+		}
+
+		const keepRunning = animation.onFrame(state, 1000)
+
+		expect(keepRunning).toBe(false)
+		expect(state.direction).toBe(-1)
+		expect(state.current).toBe(100)
+		expect(randomizeColorMock).toHaveBeenCalled()
+		expect(onBounceMock).toHaveBeenCalled()
+		expect(impactAsyncMock).toHaveBeenCalled()
+	})
+
+	it('withBouncing - Should clamp and reverse direction at the bottom bound', () => {
+		randomizeColorMock.mockReset()
+
+		const animation = animationUtils.withBouncing(
+			60,
+			10,
+			90,
+			randomizeColorMock
+		)
+
+		if (typeof animation === 'number') {
+			throw new Error('Expected animation callbacks')
+		}
+
+		const state = {
+			current: 12,
+			lastTimestamp: 0,
+			direction: -1
+		}
+
+		animation.onFrame(state, 1000)
+
+		expect(state.direction).toBe(1)
+		expect(state.current).toBe(10)
+		expect(randomizeColorMock).toHaveBeenCalled()
+	})
+})

--- a/src/utils/tests/calendar-utils.test.ts
+++ b/src/utils/tests/calendar-utils.test.ts
@@ -11,9 +11,11 @@ const mockGetExams = mock(async (): Promise<Exams[]> => [])
 mock.module('react-native', () => ({
 	__esModule: true,
 	default: {
-		Platform: { OS: 'web' }
+		Platform: { OS: 'web' },
+		Linking: { openURL: async () => {} }
 	},
-	Platform: { OS: 'web' }
+	Platform: { OS: 'web' },
+	Linking: { openURL: async () => {} }
 }))
 
 mock.module('expo-localization', () => ({

--- a/src/utils/tests/date-utils.test.ts
+++ b/src/utils/tests/date-utils.test.ts
@@ -7,6 +7,7 @@ mock.module('react-native', () => ({
 	default: {
 		Platform: { OS: 'web' },
 		Share: { share: () => Promise.resolve() },
+		Linking: { openURL: async () => {} },
 		NativeEventEmitter: class {
 			addListener() {
 				return { remove: () => {} }
@@ -20,6 +21,7 @@ mock.module('react-native', () => ({
 	},
 	Platform: { OS: 'web' },
 	Share: { share: () => Promise.resolve() },
+	Linking: { openURL: async () => {} },
 	NativeEventEmitter: class {
 		addListener() {
 			return { remove: () => {} }

--- a/src/utils/tests/events-utils.test.ts
+++ b/src/utils/tests/events-utils.test.ts
@@ -1,0 +1,288 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import type {
+	PublicEventResponse,
+	PublicOrganizerResponse
+} from '@/types/campus-life'
+import {
+	CAMPUS_LIFE_PUBLIC_ORGANIZER_KIND_STUDENT_ASSOCIATION,
+	CAMPUS_LIFE_PUBLIC_ORGANIZER_KIND_THI_DEPARTMENT
+} from '@/types/campus-life'
+
+const SRC_ROOT = new URL('../../', import.meta.url).pathname
+
+const mockGetPublicCampusLifeEvents = mock(
+	async () => [] as PublicEventResponse[]
+)
+const mockGetPublicCampusLifeEvent = mock(
+	async (): Promise<PublicEventResponse> => ({
+		id: 1,
+		organizer_id: 10,
+		title_de: 'Fallback Event',
+		title_en: 'Fallback Event',
+		start_date_time: '2030-01-01T10:00:00Z',
+		end_date_time: '2030-01-01T12:00:00Z'
+	})
+)
+const mockGetPublicOrganizer = mock(
+	async (): Promise<PublicOrganizerResponse> => ({
+		id: 10,
+		name: 'Fallback Organizer'
+	})
+)
+const mockGetPublicOrganizers = mock(
+	async (): Promise<PublicOrganizerResponse[]> => []
+)
+const mockGetUniversitySports = mock(async () => ({
+	universitySports: []
+}))
+const mockGetFragmentData = mock(() => null as unknown)
+
+const registerEventsApiMocks = () => {
+	mock.module(`${SRC_ROOT}api/neuland-api.ts`, () => ({
+		default: {
+			getPublicCampusLifeEvents: mockGetPublicCampusLifeEvents,
+			getPublicCampusLifeEvent: mockGetPublicCampusLifeEvent,
+			getPublicOrganizer: mockGetPublicOrganizer,
+			getPublicOrganizers: mockGetPublicOrganizers,
+			getUniversitySports: mockGetUniversitySports
+		}
+	}))
+
+	mock.module(`${SRC_ROOT}__generated__/gql/index.ts`, () => ({
+		getFragmentData: mockGetFragmentData
+	}))
+}
+
+mock.module(`${SRC_ROOT}__generated__/gql/graphql.ts`, () => ({
+	FoodFieldsFragmentDoc: {},
+	UniversitySportsFieldsFragmentDoc: {}
+}))
+
+let eventsUtils: typeof import('../events-utils')
+
+beforeAll(async () => {
+	registerEventsApiMocks()
+	eventsUtils = await import('../events-utils')
+})
+
+describe('events-utils', () => {
+	it('sportsCategories - Should expose expected sport keys and icon mappings', () => {
+		expect(eventsUtils.sportsCategories.Basketball).toEqual({
+			iosIcon: 'figure.basketball',
+			androidIcon: 'sports_basketball'
+		})
+		expect(eventsUtils.sportsCategories.Running).toEqual({
+			iosIcon: 'figure.run',
+			androidIcon: 'directions_run'
+		})
+		expect(eventsUtils.sportsCategories.Other.androidIcon).toBe('sports')
+		expect(Object.keys(eventsUtils.sportsCategories)).toContain('Yoga')
+	})
+
+	it('loadCampusLifeEvents - Should map API events and filter empty titles and past events', async () => {
+		mockGetPublicCampusLifeEvents.mockResolvedValueOnce([
+			{
+				id: 1,
+				organizer_id: 5,
+				organizer_kind: 'STUDENT_ASSOCIATION',
+				organizer_name: 'Neuland',
+				title_de: '  ',
+				title_en: '',
+				start_date_time: '2030-06-01T18:00:00Z',
+				end_date_time: '2030-06-01T20:00:00Z'
+			},
+			{
+				id: 2,
+				organizer_id: 6,
+				organizer_kind: 'THI_DEPARTMENT',
+				organizer_name: null,
+				title_de: 'Past Event',
+				title_en: 'Past Event',
+				start_date_time: '2020-01-01T10:00:00Z',
+				end_date_time: '2020-01-01T12:00:00Z'
+			},
+			{
+				id: 3,
+				organizer_id: 7,
+				title_de: 'Future Event',
+				title_en: 'Future Event',
+				description_de: 'Beschreibung',
+				start_date_time: '2030-07-01T10:00:00Z',
+				end_date_time: '2030-07-01T12:00:00Z',
+				location: 'Aula',
+				event_url: 'https://example.com'
+			}
+		])
+
+		const events = await eventsUtils.loadCampusLifeEvents({
+			organizerKind: CAMPUS_LIFE_PUBLIC_ORGANIZER_KIND_STUDENT_ASSOCIATION,
+			upcomingOnly: true,
+			limit: 10
+		})
+
+		expect(mockGetPublicCampusLifeEvents).toHaveBeenCalledWith({
+			organizerId: undefined,
+			upcomingOnly: true,
+			limit: 10,
+			offset: undefined,
+			organizerKind: CAMPUS_LIFE_PUBLIC_ORGANIZER_KIND_STUDENT_ASSOCIATION
+		})
+		expect(events).toHaveLength(1)
+		expect(events[0]).toMatchObject({
+			id: '3',
+			numericId: 3,
+			titles: { de: 'Future Event', en: 'Future Event' },
+			location: 'Aula',
+			eventUrl: 'https://example.com',
+			host: {
+				id: 7,
+				name: 'Campus Life'
+			}
+		})
+	})
+
+	it('loadCampusLifeEvent - Should map a single event with organizer fallbacks', async () => {
+		mockGetPublicCampusLifeEvent.mockResolvedValueOnce({
+			id: 42,
+			organizer_id: 99,
+			organizer_kind: 'THI_DEPARTMENT',
+			organizer_name: 'Faculty of Computer Science',
+			title_de: 'Vortrag',
+			title_en: 'Lecture',
+			description_en: 'Details',
+			start_date_time: '2030-03-01T14:00:00Z',
+			end_date_time: '2030-03-01T16:00:00Z'
+		})
+
+		const event = await eventsUtils.loadCampusLifeEvent(42)
+
+		expect(event).toMatchObject({
+			id: '42',
+			organizerKind: CAMPUS_LIFE_PUBLIC_ORGANIZER_KIND_THI_DEPARTMENT,
+			host: {
+				id: 99,
+				name: 'Faculty of Computer Science'
+			}
+		})
+	})
+
+	it('loadCampusLifeOrganizer - Should map organizer fields with null fallbacks', async () => {
+		mockGetPublicOrganizer.mockResolvedValueOnce({
+			id: 12,
+			organizer_kind: 'STUDENT_ASSOCIATION',
+			name: 'Robotics Club',
+			description_de: null,
+			description_en: 'We build robots',
+			instagram_url: 'https://instagram.com/robotics',
+			website_url: null,
+			location: 'Lab 1'
+		})
+
+		const organizer = await eventsUtils.loadCampusLifeOrganizer(12)
+
+		expect(organizer).toEqual({
+			id: 12,
+			organizerKind: CAMPUS_LIFE_PUBLIC_ORGANIZER_KIND_STUDENT_ASSOCIATION,
+			name: 'Robotics Club',
+			descriptions: { de: null, en: 'We build robots' },
+			location: 'Lab 1',
+			instagram: 'https://instagram.com/robotics',
+			website: null,
+			linkedin: null,
+			nonProfit: null,
+			registrationNumber: null
+		})
+	})
+
+	it('loadCampusLifeOrganizers - Should map a list of organizers', async () => {
+		mockGetPublicOrganizers.mockResolvedValueOnce([
+			{
+				id: 1,
+				name: 'Club A',
+				organizer_kind: 'STUDENT_ASSOCIATION'
+			},
+			{
+				id: 2,
+				name: 'Department B',
+				organizer_kind: 'THI_DEPARTMENT'
+			}
+		])
+
+		const organizers = await eventsUtils.loadCampusLifeOrganizers(
+			CAMPUS_LIFE_PUBLIC_ORGANIZER_KIND_THI_DEPARTMENT
+		)
+
+		expect(organizers).toHaveLength(2)
+		expect(organizers[1].organizerKind).toBe(
+			CAMPUS_LIFE_PUBLIC_ORGANIZER_KIND_THI_DEPARTMENT
+		)
+	})
+
+	it('loadUniversitySportsEvents - Should return an empty list when fragment data is missing', async () => {
+		mockGetUniversitySports.mockResolvedValueOnce({
+			universitySports: null
+		} as unknown as Awaited<ReturnType<typeof mockGetUniversitySports>>)
+		mockGetFragmentData.mockReturnValueOnce(null)
+
+		await expect(eventsUtils.loadUniversitySportsEvents()).resolves.toEqual([])
+	})
+
+	it('loadUniversitySportsEvents - Should group events by weekday in calendar order', async () => {
+		mockGetUniversitySports.mockResolvedValueOnce({
+			universitySports: ['payload']
+		} as unknown as Awaited<ReturnType<typeof mockGetUniversitySports>>)
+		mockGetFragmentData.mockReturnValueOnce([
+			{
+				id: '1',
+				weekday: 'Wednesday',
+				campus: 'INGOLSTADT',
+				location: 'Sports hall',
+				startTime: '18:00',
+				endTime: '19:30',
+				requiresRegistration: false,
+				invitationLink: null,
+				eMail: null,
+				sportsCategory: 'Basketball',
+				title: { de: 'Basketball', en: 'Basketball' },
+				description: null
+			},
+			{
+				id: '2',
+				weekday: 'Monday',
+				campus: 'INGOLSTADT',
+				location: 'Gym',
+				startTime: '17:00',
+				endTime: null,
+				requiresRegistration: true,
+				invitationLink: null,
+				eMail: null,
+				sportsCategory: 'Yoga',
+				title: { de: 'Yoga', en: 'Yoga' },
+				description: null
+			}
+		])
+
+		const sections = await eventsUtils.loadUniversitySportsEvents()
+
+		expect(sections).toEqual([
+			{
+				title: 'Monday',
+				data: [
+					expect.objectContaining({
+						id: '2',
+						weekday: 'Monday'
+					})
+				]
+			},
+			{
+				title: 'Wednesday',
+				data: [
+					expect.objectContaining({
+						id: '1',
+						weekday: 'Wednesday'
+					})
+				]
+			}
+		])
+	})
+})

--- a/src/utils/tests/food-utils.test.ts
+++ b/src/utils/tests/food-utils.test.ts
@@ -6,7 +6,7 @@ const SRC_ROOT = new URL('../../', import.meta.url).pathname
 
 const platform = { OS: 'web' as 'web' | 'ios' | 'android' }
 const shareMock = mock(async () => {})
-const copyToClipboardMock = mock(async () => {})
+const clipboardSetStringAsyncMock = mock(async () => {})
 const trackEventMock = mock(() => {})
 const mockGetFoodPlan = mock(
 	async (): Promise<{ food: unknown }> => ({ food: [] })
@@ -30,6 +30,7 @@ mock.module('react-native', () => ({
 	default: {
 		Platform: platform,
 		Share: { share: shareMock },
+		Linking: { openURL: async () => {} },
 		NativeEventEmitter: class {
 			addListener() {
 				return { remove: () => {} }
@@ -43,6 +44,7 @@ mock.module('react-native', () => ({
 	},
 	Platform: platform,
 	Share: { share: shareMock },
+	Linking: { openURL: async () => {} },
 	NativeEventEmitter: class {
 		addListener() {
 			return { remove: () => {} }
@@ -60,30 +62,29 @@ mock.module('@aptabase/react-native', () => ({
 }))
 
 mock.module('expo-clipboard', () => ({
-	setStringAsync: async () => {}
+	setStringAsync: clipboardSetStringAsyncMock
 }))
 
 mock.module('burnt', () => ({
 	toast: () => {}
 }))
 
-mock.module(`${SRC_ROOT}utils/ui-utils.ts`, () => ({
-	copyToClipboard: copyToClipboardMock
-}))
-
-mock.module(`${SRC_ROOT}__generated__/gql/index.ts`, () => ({
-	getFragmentData: mockGetFragmentData
-}))
-
 mock.module(`${SRC_ROOT}__generated__/gql/graphql.ts`, () => ({
-	FoodFieldsFragmentDoc: {}
+	FoodFieldsFragmentDoc: {},
+	UniversitySportsFieldsFragmentDoc: {}
 }))
 
-mock.module(`${SRC_ROOT}api/neuland-api.ts`, () => ({
-	default: {
-		getFoodPlan: mockGetFoodPlan
-	}
-}))
+const registerFoodApiMocks = () => {
+	mock.module(`${SRC_ROOT}__generated__/gql/index.ts`, () => ({
+		getFragmentData: mockGetFragmentData
+	}))
+
+	mock.module(`${SRC_ROOT}api/neuland-api.ts`, () => ({
+		default: {
+			getFoodPlan: mockGetFoodPlan
+		}
+	}))
+}
 
 let foodUtils: typeof import('../food-utils')
 
@@ -115,6 +116,7 @@ const makeMeal = (id: string, isStatic: boolean): Meal =>
 	}) as Meal
 
 beforeAll(async () => {
+	registerFoodApiMocks()
 	foodUtils = await import('../food-utils')
 })
 
@@ -337,7 +339,7 @@ describe('food-utils', () => {
 	it('shareMeal - Should track analytics and copy the message on web', () => {
 		platform.OS = 'web'
 		trackEventMock.mockReset()
-		copyToClipboardMock.mockReset()
+		clipboardSetStringAsyncMock.mockReset()
 		shareMock.mockReset()
 
 		const meal = makeMeal('share-meal', false)
@@ -361,7 +363,7 @@ describe('food-utils', () => {
 		foodUtils.shareMeal(meal, i18nMock, 'student')
 
 		expect(trackEventMock).toHaveBeenCalledWith('Share', { type: 'meal' })
-		expect(copyToClipboardMock).toHaveBeenCalledWith(
+		expect(clipboardSetStringAsyncMock).toHaveBeenCalledWith(
 			'share:Gericht share-meal:2.50 €:Mensa Ingolstadt:share-meal'
 		)
 		expect(shareMock).not.toHaveBeenCalled()
@@ -370,7 +372,7 @@ describe('food-utils', () => {
 	it('shareMeal - Should open the native share sheet off web', () => {
 		platform.OS = 'ios'
 		trackEventMock.mockReset()
-		copyToClipboardMock.mockReset()
+		clipboardSetStringAsyncMock.mockReset()
 		shareMock.mockReset()
 
 		const meal = makeMeal('native-meal', false)
@@ -396,7 +398,7 @@ describe('food-utils', () => {
 		expect(shareMock).toHaveBeenCalledWith({
 			message: 'native:Gericht native-meal:native-meal'
 		})
-		expect(copyToClipboardMock).not.toHaveBeenCalled()
+		expect(clipboardSetStringAsyncMock).not.toHaveBeenCalled()
 
 		platform.OS = 'web'
 	})

--- a/src/utils/tests/grades-utils.test.ts
+++ b/src/utils/tests/grades-utils.test.ts
@@ -1,0 +1,246 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import type { SpoWeights } from '@/types/asset-api'
+import type { Grade } from '@/types/thi-api'
+
+const SRC_ROOT = new URL('../../', import.meta.url).pathname
+
+const mockGetGrades = mock(async (): Promise<Grade[]> => [])
+
+mock.module(`${SRC_ROOT}api/authenticated-api.ts`, () => ({
+	default: {
+		getGrades: mockGetGrades
+	}
+}))
+
+let gradesUtils: typeof import('../grades-utils')
+
+const makeGrade = (overrides: Partial<Grade> = {}): Grade => ({
+	stg: 'EI',
+	kztn: 'k',
+	pon: '1',
+	titel: 'Mathematik',
+	ects: '5',
+	fristsem: 'WS24/25',
+	note: '1.3',
+	frwpf: '',
+	anrech: '',
+	...overrides
+})
+
+beforeAll(async () => {
+	gradesUtils = await import('../grades-utils')
+})
+
+describe('grades-utils', () => {
+	beforeEach(() => {
+		mockGetGrades.mockReset()
+		mockGetGrades.mockImplementation(async () => [])
+	})
+	it('loadGrades - Should return empty finished and missing lists for no grades', async () => {
+		mockGetGrades.mockResolvedValueOnce([])
+
+		await expect(gradesUtils.loadGrades()).resolves.toEqual({
+			finished: [],
+			missing: []
+		})
+	})
+
+	it('loadGrades - Should normalize empty notes to E* when anrech is asterisk', async () => {
+		mockGetGrades.mockResolvedValueOnce([
+			makeGrade({ note: '', anrech: '*', titel: 'Praktikum' })
+		])
+
+		const { finished } = await gradesUtils.loadGrades()
+
+		expect(finished).toHaveLength(1)
+		expect(finished[0].note).toBe('E*')
+	})
+
+	it('loadGrades - Should normalize linked empty notes to E when another pon has a grade', async () => {
+		mockGetGrades.mockResolvedValueOnce([
+			makeGrade({ pon: '42', note: '', titel: 'Projekt A' }),
+			makeGrade({ pon: '42', note: '2.0', titel: 'Projekt B' })
+		])
+
+		const { finished } = await gradesUtils.loadGrades()
+
+		expect(finished.some((grade) => grade.note === 'E')).toBe(true)
+	})
+
+	it('loadGrades - Should keep the duplicate title with the highest ECTS value', async () => {
+		mockGetGrades.mockResolvedValueOnce([
+			makeGrade({
+				pon: '1',
+				titel: 'Software Engineering',
+				ects: '5',
+				note: '2.0'
+			}),
+			makeGrade({
+				pon: '2',
+				titel: 'Software Engineering',
+				ects: '9',
+				note: '1.7'
+			}),
+			makeGrade({ pon: '3', titel: 'Datenbanken', ects: '5', note: '' })
+		])
+
+		const { finished, missing } = await gradesUtils.loadGrades()
+
+		expect(finished).toHaveLength(1)
+		expect(finished[0]).toMatchObject({
+			titel: 'Software Engineering',
+			ects: '9',
+			note: '2.0'
+		})
+		expect(missing).toHaveLength(1)
+		expect(missing[0].titel).toBe('Datenbanken')
+	})
+
+	it('loadGrades - Should treat grades of 5.0 or higher as missing', async () => {
+		mockGetGrades.mockResolvedValueOnce([
+			makeGrade({ titel: 'Passed', note: '4.0' }),
+			makeGrade({ titel: 'Failed', note: '5.0' })
+		])
+
+		const { finished, missing } = await gradesUtils.loadGrades()
+
+		expect(finished.map((grade) => grade.titel)).toEqual(['Passed'])
+		expect(missing.map((grade) => grade.titel)).toEqual(['Failed'])
+	})
+
+	it('calculateECTS - Should sum ECTS from finished grades', async () => {
+		mockGetGrades.mockResolvedValueOnce([
+			makeGrade({ pon: '1', titel: 'A', ects: '5', note: '1.0' }),
+			makeGrade({ pon: '2', titel: 'B', ects: '7', note: '2.0' }),
+			makeGrade({ pon: '3', titel: 'C', ects: '6', note: '' })
+		])
+
+		await expect(gradesUtils.calculateECTS()).resolves.toBe(12)
+	})
+
+	it('loadGradeAverage - Should throw when SPO data is missing', async () => {
+		mockGetGrades.mockResolvedValueOnce([makeGrade()])
+
+		await expect(gradesUtils.loadGradeAverage(null, null)).rejects.toThrow(
+			'Failed to load data'
+		)
+		await expect(
+			gradesUtils.loadGradeAverage({ 'SPO 2020': [] }, 'Unknown SPO')
+		).rejects.toThrow('Failed to load data')
+	})
+
+	it('loadGradeAverage - Should calculate weighted averages from SPO data', async () => {
+		mockGetGrades.mockResolvedValueOnce([
+			makeGrade({ titel: 'Mathematik I', note: '2.0' }),
+			makeGrade({ titel: 'Programmieren', note: '1.5' })
+		])
+
+		const courseSPOs: SpoWeights = {
+			'Informatik SPO': [
+				{
+					apo_number: '1',
+					name: 'Mathematik I',
+					weekly_workload: 4,
+					weight: 2,
+					ects: 5
+				},
+				{
+					apo_number: '2',
+					name: 'Programmieren',
+					weekly_workload: 6,
+					weight: 3,
+					ects: 8
+				}
+			]
+		}
+
+		const average = await gradesUtils.loadGradeAverage(
+			courseSPOs,
+			'Informatik SPO'
+		)
+
+		expect(average.result).toBe(1.7)
+		expect(average.entries).toHaveLength(2)
+		expect(average.missingWeight).toBe(0)
+		expect(average.resultMin).toBeLessThanOrEqual(average.resultMax)
+	})
+
+	it('loadGradeAverage - Should count missing weights for unmatched modules', async () => {
+		mockGetGrades.mockResolvedValueOnce([
+			makeGrade({ titel: 'Unmapped Module', note: '2.0' })
+		])
+
+		const courseSPOs: SpoWeights = {
+			'Informatik SPO': [
+				{
+					apo_number: '1',
+					name: 'Other Module',
+					weekly_workload: 4,
+					weight: 2,
+					ects: 5
+				}
+			]
+		}
+
+		const average = await gradesUtils.loadGradeAverage(
+			courseSPOs,
+			'Informatik SPO'
+		)
+
+		expect(average.missingWeight).toBe(1)
+		expect(average.entries[0]).toMatchObject({
+			name: 'Unmapped Module',
+			weight: null,
+			grade: 2
+		})
+	})
+
+	it('loadGradeAverage - Should keep the first grade when duplicate SPO names appear', async () => {
+		mockGetGrades.mockResolvedValueOnce([
+			makeGrade({ titel: 'Mathematik I', note: '2.0' }),
+			makeGrade({ titel: 'Mathematik I', note: '1.3' })
+		])
+
+		const courseSPOs: SpoWeights = {
+			'Informatik SPO': [
+				{
+					apo_number: '1',
+					name: 'Mathematik I',
+					weekly_workload: 4,
+					weight: 2,
+					ects: 5
+				}
+			]
+		}
+
+		const average = await gradesUtils.loadGradeAverage(
+			courseSPOs,
+			'Informatik SPO'
+		)
+
+		expect(average.entries).toHaveLength(1)
+		expect(average.entries[0].grade).toBe(2)
+	})
+
+	it('loadGradeAverage - Should throw when total weight is zero', async () => {
+		mockGetGrades.mockResolvedValueOnce([
+			makeGrade({ titel: 'Zero Weight Module', note: '2.0' })
+		])
+
+		const courseSPOs: SpoWeights = {
+			'Informatik SPO': [
+				{
+					apo_number: '1',
+					name: 'Zero Weight Module',
+					weekly_workload: 4,
+					weight: 0,
+					ects: 5
+				}
+			]
+		}
+
+		await expect(
+			gradesUtils.loadGradeAverage(courseSPOs, 'Informatik SPO')
+		).rejects.toThrow('Failed to calculate average')
+	})
+})

--- a/src/utils/tests/linking.test.ts
+++ b/src/utils/tests/linking.test.ts
@@ -1,35 +1,28 @@
-import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import { describe, expect, it, mock } from 'bun:test'
 
 const openURLMock = mock(async () => {})
 const trackEventMock = mock(() => {})
 
-const registerLinkingMocks = () => {
-	mock.module('react-native', () => ({
-		__esModule: true,
-		default: {
-			Linking: { openURL: openURLMock },
-			Platform: { OS: 'web' }
-		},
+mock.module('react-native', () => ({
+	__esModule: true,
+	default: {
 		Linking: { openURL: openURLMock },
 		Platform: { OS: 'web' }
-	}))
+	},
+	Linking: { openURL: openURLMock },
+	Platform: { OS: 'web' }
+}))
 
-	mock.module('@aptabase/react-native', () => ({
-		trackEvent: trackEventMock
-	}))
-}
+mock.module('@aptabase/react-native', () => ({
+	trackEvent: trackEventMock
+}))
 
-let linking: typeof import('../linking')
-
-beforeAll(async () => {
-	registerLinkingMocks()
-	linking = await import('../linking')
-})
+const { pressLink } = await import('../linking')
 
 describe('linking', () => {
 	it('pressLink - Should be a no-op for nullish URLs', () => {
-		linking.pressLink(null)
-		linking.pressLink(undefined)
+		pressLink(null)
+		pressLink(undefined)
 
 		expect(openURLMock).not.toHaveBeenCalled()
 		expect(trackEventMock).not.toHaveBeenCalled()
@@ -39,7 +32,7 @@ describe('linking', () => {
 		openURLMock.mockReset()
 		trackEventMock.mockReset()
 
-		linking.pressLink('https://thi.de')
+		pressLink('https://thi.de')
 
 		expect(openURLMock).toHaveBeenCalledWith('https://thi.de')
 		expect(trackEventMock).not.toHaveBeenCalled()
@@ -49,7 +42,7 @@ describe('linking', () => {
 		openURLMock.mockReset()
 		trackEventMock.mockReset()
 
-		linking.pressLink('https://thi.de/events/1', 'campus-life')
+		pressLink('https://thi.de/events/1', 'campus-life')
 
 		expect(trackEventMock).toHaveBeenCalledWith('EventLink', {
 			link: 'campus-life'

--- a/src/utils/tests/linking.test.ts
+++ b/src/utils/tests/linking.test.ts
@@ -1,0 +1,59 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test'
+
+const openURLMock = mock(async () => {})
+const trackEventMock = mock(() => {})
+
+const registerLinkingMocks = () => {
+	mock.module('react-native', () => ({
+		__esModule: true,
+		default: {
+			Linking: { openURL: openURLMock },
+			Platform: { OS: 'web' }
+		},
+		Linking: { openURL: openURLMock },
+		Platform: { OS: 'web' }
+	}))
+
+	mock.module('@aptabase/react-native', () => ({
+		trackEvent: trackEventMock
+	}))
+}
+
+let linking: typeof import('../linking')
+
+beforeAll(async () => {
+	registerLinkingMocks()
+	linking = await import('../linking')
+})
+
+describe('linking', () => {
+	it('pressLink - Should be a no-op for nullish URLs', () => {
+		linking.pressLink(null)
+		linking.pressLink(undefined)
+
+		expect(openURLMock).not.toHaveBeenCalled()
+		expect(trackEventMock).not.toHaveBeenCalled()
+	})
+
+	it('pressLink - Should open the URL without analytics when no tag is provided', () => {
+		openURLMock.mockReset()
+		trackEventMock.mockReset()
+
+		linking.pressLink('https://thi.de')
+
+		expect(openURLMock).toHaveBeenCalledWith('https://thi.de')
+		expect(trackEventMock).not.toHaveBeenCalled()
+	})
+
+	it('pressLink - Should track EventLink analytics when a tag is provided', () => {
+		openURLMock.mockReset()
+		trackEventMock.mockReset()
+
+		linking.pressLink('https://thi.de/events/1', 'campus-life')
+
+		expect(trackEventMock).toHaveBeenCalledWith('EventLink', {
+			link: 'campus-life'
+		})
+		expect(openURLMock).toHaveBeenCalledWith('https://thi.de/events/1')
+	})
+})

--- a/src/utils/tests/map-utils.test.ts
+++ b/src/utils/tests/map-utils.test.ts
@@ -25,6 +25,7 @@ mock.module('react-native', () => ({
 	default: {
 		Platform: platform,
 		Share: { share: shareMock },
+		Linking: { openURL: async () => {} },
 		NativeEventEmitter: class {
 			addListener() {
 				return { remove: () => {} }
@@ -38,6 +39,7 @@ mock.module('react-native', () => ({
 	},
 	Platform: platform,
 	Share: { share: shareMock },
+	Linking: { openURL: async () => {} },
 	NativeEventEmitter: class {
 		addListener() {
 			return { remove: () => {} }

--- a/src/utils/tests/map-utils.test.ts
+++ b/src/utils/tests/map-utils.test.ts
@@ -3,6 +3,11 @@ import { SEARCH_TYPES } from '@/types/map'
 
 const UTILS_ROOT = new URL('../', import.meta.url).pathname
 
+const platform = { OS: 'web' as 'web' | 'ios' | 'android' }
+const shareMock = mock(async () => {})
+const trackEventMock = mock(() => {})
+const clipboardSetStringAsyncMock = mock(async () => {})
+
 mock.module(`${UTILS_ROOT}../localization/i18n.ts`, () => ({
 	default: { language: 'de' }
 }))
@@ -18,8 +23,8 @@ mock.module('react-i18next', () => ({
 mock.module('react-native', () => ({
 	__esModule: true,
 	default: {
-		Platform: { OS: 'web' },
-		Share: { share: () => Promise.resolve() },
+		Platform: platform,
+		Share: { share: shareMock },
 		NativeEventEmitter: class {
 			addListener() {
 				return { remove: () => {} }
@@ -31,8 +36,8 @@ mock.module('react-native', () => ({
 			getEnforcing: () => null
 		}
 	},
-	Platform: { OS: 'web' },
-	Share: { share: () => Promise.resolve() },
+	Platform: platform,
+	Share: { share: shareMock },
 	NativeEventEmitter: class {
 		addListener() {
 			return { remove: () => {} }
@@ -46,11 +51,11 @@ mock.module('react-native', () => ({
 }))
 
 mock.module('@aptabase/react-native', () => ({
-	trackEvent: () => {}
+	trackEvent: trackEventMock
 }))
 
 mock.module('expo-clipboard', () => ({
-	setStringAsync: async () => {}
+	setStringAsync: clipboardSetStringAsyncMock
 }))
 
 mock.module('burnt', () => ({
@@ -62,6 +67,30 @@ mock.module('i18next', () => ({
 }))
 
 let mapUtils: typeof import('../map-utils')
+
+const withMockedCurrentDate = (fixedDate: Date, run: () => void): void => {
+	const OriginalDate = globalThis.Date
+	globalThis.Date = class extends OriginalDate {
+		constructor(...args: [] | [Date | number | string]) {
+			if (args.length === 0) {
+				super(fixedDate.getTime())
+				return
+			}
+
+			super(args[0])
+		}
+
+		static now(): number {
+			return fixedDate.getTime()
+		}
+	} as typeof Date
+
+	try {
+		run()
+	} finally {
+		globalThis.Date = OriginalDate
+	}
+}
 
 beforeAll(async () => {
 	mapUtils = await import('../map-utils')
@@ -468,5 +497,63 @@ describe('map-utils', () => {
 			ios: 'mappin',
 			android: 'location_on'
 		})
+	})
+
+	it('getNextValidDate - Should move Saturday evening to Monday morning', () => {
+		withMockedCurrentDate(new Date('2026-06-20T21:00:00'), () => {
+			const result = mapUtils.getNextValidDate()
+
+			expect(result.wasModified).toBe(true)
+			expect(result.startDate.getDay()).toBe(1)
+			expect(result.startDate.getHours()).toBe(8)
+			expect(result.startDate.getMinutes()).toBe(15)
+		})
+	})
+
+	it('getNextValidDate - Should move Sunday dates to Monday morning', () => {
+		withMockedCurrentDate(new Date('2026-06-21T10:00:00'), () => {
+			const result = mapUtils.getNextValidDate()
+
+			expect(result.wasModified).toBe(true)
+			expect(result.startDate.getDay()).toBe(1)
+		})
+	})
+
+	it('getNextValidDate - Should move early weekday mornings to 08:15', () => {
+		withMockedCurrentDate(new Date('2026-06-18T06:30:00'), () => {
+			const result = mapUtils.getNextValidDate()
+
+			expect(result.wasModified).toBe(true)
+			expect(result.startDate.getHours()).toBe(8)
+			expect(result.startDate.getMinutes()).toBe(15)
+		})
+	})
+
+	it('handleShareModal - Should copy the room link on web', () => {
+		platform.OS = 'web'
+		trackEventMock.mockReset()
+		clipboardSetStringAsyncMock.mockReset()
+
+		mapUtils.handleShareModal('G101')
+
+		expect(trackEventMock).toHaveBeenCalledWith('Share', { type: 'room' })
+		expect(clipboardSetStringAsyncMock).toHaveBeenCalledWith(
+			'https://web.neuland.app/map/?room=G101'
+		)
+
+		platform.OS = 'web'
+	})
+
+	it('handleShareModal - Should use the native share sheet off web', () => {
+		platform.OS = 'ios'
+		shareMock.mockReset()
+
+		mapUtils.handleShareModal('H201')
+
+		expect(shareMock).toHaveBeenCalledWith({
+			url: 'https://web.neuland.app/map/?room=H201'
+		})
+
+		platform.OS = 'web'
 	})
 })

--- a/src/utils/tests/timetable-utils.test.ts
+++ b/src/utils/tests/timetable-utils.test.ts
@@ -325,4 +325,114 @@ describe('timetable-utils', () => {
 		expect(result).toHaveLength(1)
 		expect(result[0].shortName).toBe('MATH')
 	})
+
+	it('getFriendlyTimetable - Should adjust August dates to October', async () => {
+		mockGetTimetable.mockReset()
+		mockGetTimetable.mockResolvedValue({
+			timetable: [],
+			holidays: [],
+			semester: []
+		})
+
+		await timetableUtils.getFriendlyTimetable(new Date('2026-08-15T00:00:00'))
+
+		expect(mockGetTimetable).toHaveBeenCalled()
+		const calls = mockGetTimetable.mock.calls as unknown as [Date, boolean][]
+		expect(calls[0]?.[0].getMonth()).toBe(9)
+	})
+
+	it('getFriendlyTimetable - Should merge hours for duplicate dates across month requests', async () => {
+		mockGetTimetable.mockReset()
+		const sharedDate = new Date('2026-04-07T00:00:00')
+		const hourEntry = {
+			von: new Date('2026-04-07T10:00:00'),
+			bis: new Date('2026-04-07T11:30:00'),
+			lvId: 'B',
+			details: {
+				raum: 'H201',
+				fach: 'Programmieren',
+				veranstaltung: 'PRG - Programmieren',
+				dozent: 'Prof. Y',
+				stg: 'INF',
+				stgru: 'INF1',
+				teilgruppe: '',
+				sws: '2',
+				ectspoints: '5',
+				pruefung: 'Klausur',
+				ziel: null,
+				inhalt: null,
+				literatur: null
+			}
+		}
+
+		mockGetTimetable
+			.mockResolvedValueOnce({
+				timetable: [
+					{
+						date: sharedDate,
+						hours: {
+							1: [
+								{
+									von: new Date('2026-04-07T08:15:00'),
+									bis: new Date('2026-04-07T09:45:00'),
+									lvId: 'A',
+									details: {
+										raum: 'G101',
+										fach: 'Mathematik',
+										veranstaltung: 'MATH - Mathematik 1',
+										dozent: 'Prof. X',
+										stg: 'INF',
+										stgru: 'INF1',
+										teilgruppe: '',
+										sws: '2',
+										ectspoints: '5',
+										pruefung: 'Klausur',
+										ziel: null,
+										inhalt: null,
+										literatur: null
+									}
+								}
+							]
+						}
+					}
+				],
+				holidays: [],
+				semester: []
+			})
+			.mockResolvedValueOnce({
+				timetable: [
+					{
+						date: sharedDate,
+						hours: {
+							2: [hourEntry]
+						}
+					}
+				],
+				holidays: [],
+				semester: []
+			})
+
+		const result = await timetableUtils.getFriendlyTimetable(sharedDate)
+
+		expect(result).toHaveLength(2)
+		expect(result.map((entry) => entry.shortName)).toEqual(['MATH', 'PRG'])
+	})
+
+	it('getGroupedTimetable - Should handle timed calendar events without an end date', () => {
+		const grouped = timetableUtils.getGroupedTimetable([], [], true, [
+			{
+				id: 'timed-1',
+				name: { de: 'Workshop', en: 'Workshop' },
+				begin: new Date('2026-04-07T14:00:00'),
+				hasHours: true
+			}
+		])
+
+		expect(grouped).toHaveLength(1)
+		expect(grouped[0].data[0]).toMatchObject({
+			name: { de: 'Workshop', en: 'Workshop' },
+			eventType: 'calendar',
+			isAllDay: false
+		})
+	})
 })

--- a/src/utils/tests/timetable-utils.test.ts
+++ b/src/utils/tests/timetable-utils.test.ts
@@ -9,6 +9,7 @@ mock.module('react-native', () => ({
 	default: {
 		Platform: { OS: 'web' },
 		Share: { share: () => Promise.resolve() },
+		Linking: { openURL: async () => {} },
 		NativeEventEmitter: class {
 			addListener() {
 				return { remove: () => {} }
@@ -22,6 +23,7 @@ mock.module('react-native', () => ({
 	},
 	Platform: { OS: 'web' },
 	Share: { share: () => Promise.resolve() },
+	Linking: { openURL: async () => {} },
 	NativeEventEmitter: class {
 		addListener() {
 			return { remove: () => {} }

--- a/src/utils/tests/ui-utils.test.ts
+++ b/src/utils/tests/ui-utils.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, it, mock } from 'bun:test'
 
 const clipboardSetStringAsyncMock = mock(async () => {})
 const toastMock = mock(() => {})
+const trackEventMock = mock(() => {})
 
 mock.module('react-native', () => ({
 	__esModule: true,
@@ -46,7 +47,7 @@ mock.module('i18next', () => ({
 }))
 
 mock.module('@aptabase/react-native', () => ({
-	trackEvent: () => {}
+	trackEvent: trackEventMock
 }))
 
 let uiUtils: typeof import('../ui-utils')
@@ -116,5 +117,17 @@ describe('ui-utils', () => {
 
 		expect(clipboardSetStringAsyncMock).not.toHaveBeenCalled()
 		expect(toastMock).not.toHaveBeenCalled()
+	})
+
+	it('roomNotFoundToast - Should track analytics and show a custom toast', () => {
+		uiUtils.roomNotFoundToast('G999', '#ff0000')
+
+		expect(toastMock).toHaveBeenCalled()
+	})
+
+	it('pausedToast - Should show the paused network toast', () => {
+		uiUtils.pausedToast()
+
+		expect(toastMock).toHaveBeenCalled()
 	})
 })

--- a/src/utils/tests/ui-utils.test.ts
+++ b/src/utils/tests/ui-utils.test.ts
@@ -9,6 +9,7 @@ mock.module('react-native', () => ({
 	default: {
 		Platform: { OS: 'ios' },
 		Share: { share: () => Promise.resolve() },
+		Linking: { openURL: async () => {} },
 		NativeEventEmitter: class {
 			addListener() {
 				return { remove: () => {} }
@@ -22,6 +23,7 @@ mock.module('react-native', () => ({
 	},
 	Platform: { OS: 'ios' },
 	Share: { share: () => Promise.resolve() },
+	Linking: { openURL: async () => {} },
 	NativeEventEmitter: class {
 		addListener() {
 			return { remove: () => {} }

--- a/src/utils/tests/web-host.test.ts
+++ b/src/utils/tests/web-host.test.ts
@@ -7,9 +7,11 @@ const platform = { OS: 'web' as 'web' | 'ios' | 'android' }
 mock.module('react-native', () => ({
 	__esModule: true,
 	default: {
-		Platform: platform
+		Platform: platform,
+		Linking: { openURL: async () => {} }
 	},
-	Platform: platform
+	Platform: platform,
+	Linking: { openURL: async () => {} }
 }))
 
 let resolveAnnouncementPlatform: typeof import('../web-host').resolveAnnouncementPlatform


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #368

## Summary

Adds `bun:test` unit tests for the four previously untested pure utility modules from the issue, and extends existing tests to keep overall line coverage above the 97% target.

## New test files

| Module | Test file | Coverage focus |
|--------|-----------|----------------|
| `grades-utils.ts` | `grades-utils.test.ts` | Grade parsing, duplicate grouping, SPO average calculation |
| `events-utils.ts` | `events-utils.test.ts` | Campus Life mapping, sports categories, university sports grouping |
| `animation-utils.ts` | `animation-utils.test.ts` | `withBouncing` boundary logic |
| `linking.ts` | `linking.test.ts` | `pressLink()` no-op, URL opening, analytics |

## Additional coverage improvements

- `map-utils.test.ts`: `getNextValidDate()` and `handleShareModal()`
- `timetable-utils.test.ts`: August date adjustment, cross-month merge, timed calendar events
- `ui-utils.test.ts`: `roomNotFoundToast()` and `pausedToast()`

## Mock hygiene fixes

- Removed the partial `ui-utils` stub from `food-utils.test.ts` (verified clipboard via `expo-clipboard` instead)
- Registered API mocks in `beforeAll` where `food-utils` and `events-utils` shared `neuland-api` / GraphQL mocks
- Added `Linking` to shared `react-native` test mocks to prevent cross-file pollution

## Verification

```bash
bun run test:coverage   # 218 pass, 98.89% lines
bun lint
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4a9742c-d932-4ca3-a2e0-fe47a1dba6ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4a9742c-d932-4ca3-a2e0-fe47a1dba6ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

