### PR TITLE
fix: align dashboard masonry breakpoint at 800px

### DIFF
--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -21,6 +21,11 @@ export const unstable_settings = {
 	initialRouteName: '/'
 }
 
+const DASHBOARD_MASONRY_BREAKPOINT = 800
+
+const getDashboardColumnCount = (width: number): number =>
+	Math.floor(width < DASHBOARD_MASONRY_BREAKPOINT ? 1 : 2)
+
 const HeaderLeft = () => {
 	const { styles } = useStyles(stylesheet)
 	return (
@@ -66,7 +71,7 @@ const HomeScreen = memo(function HomeScreen() {
 	const { shownDashboardEntries } = React.use(DashboardContext)
 	const [orientation, setOrientation] = useState(Dimensions.get('window').width)
 	const [columns, setColumns] = useState(
-		Math.floor(Dimensions.get('window').width < 800 ? 1 : 2)
+		getDashboardColumnCount(Dimensions.get('window').width)
 	)
 	const { t } = useTranslation(['navigation', 'settings'])
 	const { data } = useQuery({
@@ -82,8 +87,9 @@ const HomeScreen = memo(function HomeScreen() {
 
 	useEffect(() => {
 		const handleOrientationChange = (): void => {
-			setOrientation(Dimensions.get('window').width)
-			setColumns(Math.floor(Dimensions.get('window').width < 700 ? 1 : 2))
+			const width = Dimensions.get('window').width
+			setOrientation(width)
+			setColumns(getDashboardColumnCount(width))
 		}
 
 		const subscription = Dimensions.addEventListener(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📋 Description

The dashboard masonry layout used inconsistent width thresholds for deciding between single- and two-column mode:

- Initial column count: `width < 800`
- Orientation/resize handler: `width < 700`

This caused viewports between 700–799px to render one column on first load, then switch to two columns after a resize or rotation.

This change extracts a shared `DASHBOARD_MASONRY_BREAKPOINT` constant and `getDashboardColumnCount()` helper so both code paths use the same 800px threshold.

## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web
- [ ] I’ve added or updated documentation (if needed)
- [x] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

No behavior change outside the 700–799px range; that band now consistently stays single-column until 800px.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612ae49c-0931-4451-ac7a-3454db6c8fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612ae49c-0931-4451-ac7a-3454db6c8fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

