### PR TITLE
chore: add cursor hooks for auto-format and typecheck

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,25 @@
+{
+	"version": 1,
+	"hooks": {
+		"afterFileEdit": [
+			{
+				"command": "bun run .cursor/hooks/format-file.ts"
+			},
+			{
+				"command": "bun run .cursor/hooks/typecheck-on-edit.ts",
+				"timeout": 120
+			}
+		],
+		"afterTabFileEdit": [
+			{
+				"command": "bun run .cursor/hooks/format-file.ts"
+			}
+		],
+		"stop": [
+			{
+				"command": "bun run .cursor/hooks/typecheck-stop.ts",
+				"loop_limit": 3
+			}
+		]
+	}
+}

--- a/.cursor/hooks/format-file.ts
+++ b/.cursor/hooks/format-file.ts
@@ -1,0 +1,37 @@
+import { stdin } from 'bun'
+
+interface FileEditInput {
+	file_path: string
+}
+
+const BIOME_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.json', '.jsonc'])
+
+const SKIP_PATTERNS = [
+	/\/src\/__generated__\//,
+	/\/src\/data\/licenses\.json$/,
+	/\.svg$/,
+]
+
+async function main() {
+	const input = JSON.parse(await stdin.text()) as FileEditInput
+	const filePath = input.file_path
+
+	if (!filePath) return
+
+	const extension = filePath.slice(filePath.lastIndexOf('.'))
+	if (!BIOME_EXTENSIONS.has(extension)) return
+	if (SKIP_PATTERNS.some((pattern) => pattern.test(filePath))) return
+
+	const result = await Bun.$`bunx biome check --fix --no-errors-on-unmatched ${filePath}`
+		.quiet()
+		.nothrow()
+
+	if (result.exitCode !== 0) {
+		console.error(result.stderr.toString() || result.stdout.toString())
+	}
+}
+
+main().catch((error) => {
+	console.error(error)
+	process.exit(0)
+})

--- a/.cursor/hooks/typecheck-on-edit.ts
+++ b/.cursor/hooks/typecheck-on-edit.ts
@@ -1,0 +1,63 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { stdin } from 'bun'
+
+interface FileEditInput {
+	file_path: string
+}
+
+const THROTTLE_MS = 15_000
+const MAX_OUTPUT_LINES = 30
+const STATE_DIR = '.cursor/hooks/state'
+const LAST_RUN_PATH = `${STATE_DIR}/typecheck-last-run.json`
+
+async function ensureLicenses() {
+	const licensesFile = Bun.file('src/data/licenses.json')
+	if (await licensesFile.exists()) return
+
+	await Bun.$`bun licences`.quiet().nothrow()
+}
+
+async function shouldRun(): Promise<boolean> {
+	try {
+		const state = JSON.parse(await readFile(LAST_RUN_PATH, 'utf8')) as {
+			lastRunMs: number
+		}
+		return Date.now() - state.lastRunMs >= THROTTLE_MS
+	} catch {
+		return true
+	}
+}
+
+async function markRun() {
+	await mkdir(STATE_DIR, { recursive: true })
+	await writeFile(
+		LAST_RUN_PATH,
+		JSON.stringify({ lastRunMs: Date.now() }),
+		'utf8',
+	)
+}
+
+async function main() {
+	const input = JSON.parse(await stdin.text()) as FileEditInput
+	const filePath = input.file_path
+
+	if (!filePath) return
+	if (!/\.tsx?$/.test(filePath)) return
+	if (!await shouldRun()) return
+
+	await ensureLicenses()
+
+	const result = await Bun.$`bun tsc --noEmit`.quiet().nothrow()
+	await markRun()
+
+	if (result.exitCode === 0) return
+
+	const output = result.stderr.toString() || result.stdout.toString()
+	const summary = output.split('\n').slice(0, MAX_OUTPUT_LINES).join('\n')
+	console.error(`TypeScript errors after edit:\n${summary}`)
+}
+
+main().catch((error) => {
+	console.error(error)
+	process.exit(0)
+})

--- a/.cursor/hooks/typecheck-stop.ts
+++ b/.cursor/hooks/typecheck-stop.ts
@@ -1,0 +1,42 @@
+import { stdin } from 'bun'
+
+interface StopHookInput {
+	status: 'completed' | 'aborted' | 'error'
+	loop_count: number
+}
+
+const MAX_OUTPUT_LINES = 40
+
+async function ensureLicenses() {
+	const licensesFile = Bun.file('src/data/licenses.json')
+	if (await licensesFile.exists()) return
+
+	await Bun.$`bun licences`.quiet().nothrow()
+}
+
+async function main() {
+	const input = JSON.parse(await stdin.text()) as StopHookInput
+
+	if (input.status === 'aborted') return
+
+	await ensureLicenses()
+
+	const result = await Bun.$`bun tsc --noEmit`.quiet().nothrow()
+	if (result.exitCode === 0) return
+
+	const output = result.stderr.toString() || result.stdout.toString()
+	const summary = output.split('\n').slice(0, MAX_OUTPUT_LINES).join('\n')
+
+	console.error(summary)
+	console.log(
+		JSON.stringify({
+			followup_message:
+				`TypeScript check failed. Fix the errors below, then verify with \`bun tsc --noEmit\`:\n\n${summary}`,
+		}),
+	)
+}
+
+main().catch((error) => {
+	console.error(error)
+	process.exit(0)
+})

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ my-release-key.jks
 *.geojson
 coverage/
 src/data/licenses.json
+.cursor/hooks/state/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds project-level [Cursor hooks](https://cursor.com/docs/hooks) so agent and Tab edits are auto-formatted and TypeScript errors are surfaced automatically.

### Hooks

| Event | Script | Behavior |
|-------|--------|----------|
| `afterFileEdit` | `format-file.ts` | Runs `biome check --fix` on the edited file (skips generated assets) |
| `afterFileEdit` | `typecheck-on-edit.ts` | Runs `bun tsc --noEmit` (throttled to once per 15s) when a `.ts`/`.tsx` file changes |
| `afterTabFileEdit` | `format-file.ts` | Same Biome formatting for Tab inline completions |
| `stop` | `typecheck-stop.ts` | Runs full `bun tsc --noEmit` when the agent finishes; auto-submits a follow-up message if errors remain (up to 3 loops) |

Hooks use Bun (matching the project toolchain) and generate `src/data/licenses.json` on demand when needed for `tsc`.

Cloud agents pick up `.cursor/hooks.json` automatically per Cursor docs.

## Checklist

- [x] Hook scripts tested locally via stdin piping
- [ ] Tested in Cursor IDE (requires opening the project in a trusted workspace)

## Additional Notes

- Hook runtime state (typecheck throttle timestamp) is stored in `.cursor/hooks/state/` and gitignored.
- The `stop` hook uses `loop_limit: 3` to avoid infinite fix loops when type errors persist.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cd0ce7b-7517-491b-a69f-1f481d2e63d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cd0ce7b-7517-491b-a69f-1f481d2e63d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

