### PR TITLE
build: limit dependabot bun updates to devDependencies only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
         patterns:
           - '*'
 
-  # SDK-aligned Expo / React Native deps are updated with `bun pkgs` (expo install --check).
+  # Production deps are updated with `bun pkgs` (expo install --check); Dependabot covers devDependencies only.
   - package-ecosystem: bun
     directory: /
     schedule:
@@ -33,14 +33,9 @@ updates:
       include: scope
     labels:
       - dependencies
+    allow:
+      - dependency-type: development
     groups:
-      production-minor-patch:
-        dependency-type: production
-        patterns:
-          - '*'
-        update-types:
-          - minor
-          - patch
       development-minor-patch:
         dependency-type: development
         patterns:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📋 Description

Dependabot no longer opens PRs for production Bun/npm dependencies. Production deps continue to be managed manually via `bun pkgs` (expo install --check).

Changes to `.github/dependabot.yml`:
- Added `allow: dependency-type: development` so only `devDependencies` are updated
- Removed the `production-minor-patch` group
- Kept the `development-minor-patch` group for grouped minor/patch dev updates
- Unchanged: `github-actions` and `docker` ecosystems still receive weekly updates

## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web
- [x] I’ve added or updated documentation (if needed)
- [ ] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

Existing `ignore` rules for Expo/React Native packages remain as a safety net for any SDK-related packages that might appear in `devDependencies`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ef1c7-225c-7e2e-822e-9b54c1e3f34d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ef1c7-225c-7e2e-822e-9b54c1e3f34d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

