### PR TITLE
fix: use npm for licences:bundle in Docker staging build

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -30,7 +30,7 @@ ENV EXPO_PUBLIC_FLIPT_NAMESPACE=${EXPO_PUBLIC_FLIPT_NAMESPACE}
 ENV EXPO_PUBLIC_GIT_COMMIT_HASH=${EXPO_PUBLIC_GIT_COMMIT_HASH}
 ENV NODE_ENV=production
 
-RUN bun run licences:bundle && npx expo export -p web -c
+RUN npm run licences:bundle && npx expo export -p web -c
 
 # Final stage: Serve static files using NGINX
 FROM nginx:alpine AS final

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"fmt": "biome check --fix",
 		"fmt:unsafe": "biome check --fix --unsafe",
 		"licences": "npm-license-crawler -onlyDirectDependencies -json src/data/licenses.json",
-		"licences:bundle": "bun run licences && cp src/data/licenses.json src/data/package-licenses.json",
+		"licences:bundle": "npm-license-crawler -onlyDirectDependencies -json src/data/licenses.json && cp src/data/licenses.json src/data/package-licenses.json",
 		"codegen": "graphql-codegen --config config/codegen.yml",
 		"changelog": "git cliff --config config/cliff.toml --output CHANGELOG.md",
 		"pkgs": "bunx expo install --check",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📋 Description

The staging Docker build (`Build and publish staging Docker image`) started failing after the licenses refactor switched the Dockerfile to `bun run licences:bundle`.

The Docker **build stage uses `node:26`**, which does not have Bun installed — only the earlier dependency-install stage uses `oven/bun:1`. The build failed with:

```
/bin/sh: 1: bun: not found
```

This PR fixes that by:
- Changing the Dockerfile back to `npm run licences:bundle` (matching the previous `npm run licences` pattern)
- Making `licences:bundle` call `npm-license-crawler` directly instead of chaining through `bun run licences`

## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web
- [ ] I’ve added or updated documentation (if needed)
- [ ] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

Verified locally that `npm run licences:bundle` succeeds without Bun.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3202cdf7-9e3f-4b82-a828-eb9da581fa82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3202cdf7-9e3f-4b82-a828-eb9da581fa82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

