### PR TITLE
build: improve CI with web export checks, bundle size comments, and Android PR compile

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,42 @@
+name: Setup Neuland project
+description: Checkout with Git LFS, Bun cache, and frozen lockfile install
+inputs:
+  ref:
+    description: Optional git ref to checkout
+    required: false
+    default: ''
+  fetch-depth:
+    description: Checkout fetch depth
+    required: false
+    default: '1'
+  lfs:
+    description: Enable Git LFS
+    required: false
+    default: 'true'
+  ignore-scripts:
+    description: Pass --ignore-scripts to bun install
+    required: false
+    default: 'false'
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        lfs: ${{ inputs.lfs == 'true' }}
+        ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
+        fetch-depth: ${{ inputs.fetch-depth }}
+
+    - name: Set up Bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        cache: true
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        install_flags=(--frozen-lockfile)
+        if [ "${{ inputs.ignore-scripts }}" = "true" ]; then
+          install_flags+=(--ignore-scripts)
+        fi
+        bun install "${install_flags[@]}"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,18 +1,6 @@
 name: Setup Neuland project
-description: Checkout with Git LFS, Bun cache, and frozen lockfile install
+description: Bun cache and frozen lockfile install (run actions/checkout first)
 inputs:
-  ref:
-    description: Optional git ref to checkout
-    required: false
-    default: ''
-  fetch-depth:
-    description: Checkout fetch depth
-    required: false
-    default: '1'
-  lfs:
-    description: Enable Git LFS
-    required: false
-    default: 'true'
   ignore-scripts:
     description: Pass --ignore-scripts to bun install
     required: false
@@ -20,13 +8,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        lfs: ${{ inputs.lfs == 'true' }}
-        ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
-        fetch-depth: ${{ inputs.fetch-depth }}
-
     - name: Set up Bun
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:

--- a/.github/workflows/android-pr-check.yml
+++ b/.github/workflows/android-pr-check.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Filter paths
-        uses: dorny/paths-filter@de007646406684fb567039249133adc06c2c8055 # v3.0.2
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |

--- a/.github/workflows/android-pr-check.yml
+++ b/.github/workflows/android-pr-check.yml
@@ -1,0 +1,62 @@
+name: Android PR check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: android-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect Android-related changes
+    runs-on: ubuntu-latest
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Filter paths
+        uses: dorny/paths-filter@de007646406684fb567039249133adc06c2c8055 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            android:
+              - 'app.config.json'
+              - 'config/plugins/**'
+              - 'src/assets/android/**'
+              - '**/*.android.tsx'
+              - 'package.json'
+              - 'bun.lock'
+              - 'patches/**'
+
+  android-compile:
+    name: Android prebuild and compile
+    needs: changes
+    if: |
+      needs.changes.outputs.android == 'true' ||
+      contains(toJSON(github.event.pull_request.labels.*.name), '"android"')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/setup
+
+      - name: Update license list
+        run: bun run licences:bundle
+
+      - name: Generate native Android project
+        run: bun run prebuild:android
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        with:
+          distribution: zulu
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
+
+      - name: Compile debug APK
+        working-directory: android
+        run: ./gradlew assembleDebug --no-daemon

--- a/.github/workflows/android-pr-check.yml
+++ b/.github/workflows/android-pr-check.yml
@@ -40,6 +40,11 @@ jobs:
       contains(toJSON(github.event.pull_request.labels.*.name), '"android"')
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          lfs: true
+
       - uses: ./.github/actions/setup
 
       - name: Update license list

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Generate native Android project
         run: bun run prebuild:android
 
-      - name: Generate native Android project
-        run: bun run prebuild:android
-
       - name: Set up JDK 17
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:

--- a/.github/workflows/build-webapp.yml
+++ b/.github/workflows/build-webapp.yml
@@ -54,7 +54,6 @@ jobs:
           file: config/Dockerfile
           push: true
           sbom: true
-          provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-webapp.yml
+++ b/.github/workflows/build-webapp.yml
@@ -33,6 +33,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171bb1face5a8a351bf1b4576c3934bced28 # v3.11.0
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
@@ -44,15 +47,14 @@ jobs:
             type=raw,value=staging-latest
           flavor: |
             latest=false
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: config/Dockerfile
           push: true
+          sbom: true
+          provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Filter paths
-        uses: dorny/paths-filter@de007646406684fb567039249133adc06c2c8055 # v3.0.2
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,10 +159,11 @@ jobs:
           EXPO_PUBLIC_NEULAND_GRAPHQL_ENDPOINT: ${{ vars.GRAPHQL_ENDPOINT_DEV }}
           EXPO_PUBLIC_APTABASE_KEY: ${{ secrets.EXPO_PUBLIC_APTABASE_KEY }}
         run: |
-          source config/ci/web-export-env.sh
+          cp -r config/ci /tmp/neuland-ci
           git checkout origin/main
           bun install --frozen-lockfile
-          bash config/ci/measure-web-bundle.sh base-bundle-size.json
+          source /tmp/neuland-ci/web-export-env.sh
+          bash /tmp/neuland-ci/measure-web-bundle.sh base-bundle-size.json
 
       - name: Measure PR bundle
         env:
@@ -171,9 +172,9 @@ jobs:
           EXPO_PUBLIC_APTABASE_KEY: ${{ secrets.EXPO_PUBLIC_APTABASE_KEY }}
           EXPO_PUBLIC_GIT_COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
         run: |
-          source config/ci/web-export-env.sh
           git checkout ${{ github.event.pull_request.head.sha }}
           bun install --frozen-lockfile
+          source config/ci/web-export-env.sh
           bash config/ci/measure-web-bundle.sh pr-bundle-size.json
 
       - name: Write bundle size comment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,24 +6,46 @@ on:
     branches: [main]
   merge_group:
     types: [checks_requested]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Filter paths
+        uses: dorny/paths-filter@de007646406684fb567039249133adc06c2c8055 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            web:
+              - 'src/**'
+              - '**/*.web.tsx'
+              - 'app.config.json'
+              - 'config/Dockerfile'
+              - 'config/nginx.conf'
+              - 'babel.config.js'
+              - 'tsconfig.json'
+              - 'package.json'
+              - 'bun.lock'
+              - 'patches/**'
+
   static-checks:
     name: Biome and TypeScript checks
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          lfs: true
+      - uses: ./.github/actions/setup
 
       - name: Check for merge conflict markers
         run: bash config/check-merge-conflicts.sh
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
 
       - name: Run TypeScript checks
         run: bun tsc --noEmit
@@ -33,23 +55,16 @@ jobs:
 
       - name: Check i18n
         run: bun i18n:check
+
   expo-doctor:
     name: Expo Doctor
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          lfs: true
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: Run Expo Doctor
         run: bun doctor
+
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -57,17 +72,9 @@ jobs:
       contents: read
       code-quality: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup
         with:
-          lfs: true
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
 
       - name: Run unit tests with coverage
         run: bun run test:coverage -- --reporter=junit --reporter-outfile=./junit.xml
@@ -88,3 +95,96 @@ jobs:
           report_type: test_results
           fail_ci_if_error: ${{ github.event_name == 'push' }}
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  web-export:
+    name: Web export smoke test
+    needs: changes
+    if: needs.changes.outputs.web == 'true' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/setup
+
+      - name: Export web bundle
+        env:
+          EXPO_PUBLIC_THI_API_KEY: ${{ secrets.EXPO_PUBLIC_THI_API_KEY }}
+          EXPO_PUBLIC_NEULAND_GRAPHQL_ENDPOINT: ${{ vars.GRAPHQL_ENDPOINT_DEV }}
+          EXPO_PUBLIC_APTABASE_KEY: ${{ secrets.EXPO_PUBLIC_APTABASE_KEY }}
+        run: |
+          source config/ci/web-export-env.sh
+          bash config/ci/measure-web-bundle.sh /dev/null
+
+  web-bundle-size:
+    name: Web bundle size
+    needs: changes
+    if: needs.changes.outputs.web == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          lfs: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          cache: true
+
+      - name: Measure base bundle (main)
+        env:
+          EXPO_PUBLIC_THI_API_KEY: ${{ secrets.EXPO_PUBLIC_THI_API_KEY }}
+          EXPO_PUBLIC_NEULAND_GRAPHQL_ENDPOINT: ${{ vars.GRAPHQL_ENDPOINT_DEV }}
+          EXPO_PUBLIC_APTABASE_KEY: ${{ secrets.EXPO_PUBLIC_APTABASE_KEY }}
+        run: |
+          source config/ci/web-export-env.sh
+          git checkout origin/main
+          bun install --frozen-lockfile
+          bash config/ci/measure-web-bundle.sh base-bundle-size.json
+
+      - name: Measure PR bundle
+        env:
+          EXPO_PUBLIC_THI_API_KEY: ${{ secrets.EXPO_PUBLIC_THI_API_KEY }}
+          EXPO_PUBLIC_NEULAND_GRAPHQL_ENDPOINT: ${{ vars.GRAPHQL_ENDPOINT_DEV }}
+          EXPO_PUBLIC_APTABASE_KEY: ${{ secrets.EXPO_PUBLIC_APTABASE_KEY }}
+          EXPO_PUBLIC_GIT_COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
+        run: |
+          source config/ci/web-export-env.sh
+          git checkout ${{ github.event.pull_request.head.sha }}
+          bun install --frozen-lockfile
+          bash config/ci/measure-web-bundle.sh pr-bundle-size.json
+
+      - name: Write bundle size comment
+        run: bash config/ci/compare-web-bundle-size.sh
+
+      - name: Comment on pull request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs')
+            const body = fs.readFileSync('bundle-size-comment.md', 'utf8')
+            const marker = '<!-- web-bundle-size -->'
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            })
+            const existing = comments.find((comment) => comment.body?.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              })
+              return
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
     name: Biome and TypeScript checks
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          lfs: true
+
       - uses: ./.github/actions/setup
 
       - name: Check for merge conflict markers
@@ -60,6 +65,11 @@ jobs:
     name: Expo Doctor
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          lfs: true
+
       - uses: ./.github/actions/setup
 
       - name: Run Expo Doctor
@@ -72,9 +82,13 @@ jobs:
       contents: read
       code-quality: write
     steps:
-      - uses: ./.github/actions/setup
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          lfs: true
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - uses: ./.github/actions/setup
 
       - name: Run unit tests with coverage
         run: bun run test:coverage -- --reporter=junit --reporter-outfile=./junit.xml
@@ -102,6 +116,11 @@ jobs:
     if: needs.changes.outputs.web == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          lfs: true
+
       - uses: ./.github/actions/setup
 
       - name: Export web bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-android
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          lfs: true
+
       - uses: ./.github/actions/setup
         with:
           ignore-scripts: 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,9 @@ jobs:
         id: tag_name
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171bb1face5a8a351bf1b4576c3934bced28 # v3.11.0
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
@@ -112,6 +115,8 @@ jobs:
           context: .
           file: config/Dockerfile
           push: true
+          sbom: true
+          provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             ${{ steps.meta.outputs.labels }}
@@ -158,9 +163,6 @@ jobs:
       - name: Generate native Android project
         run: bun run prebuild:android
 
-      - name: Generate native Android project
-        run: bun run prebuild:android
-
       - name: Set up JDK 17
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
@@ -186,23 +188,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-android
     steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup
         with:
-          lfs: true
-
-      - name: Setup Node JS environment
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "22"
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: latest
-
-      - name: Install project dependencies
-        run: bun install
+          ignore-scripts: 'true'
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,6 @@ jobs:
           file: config/Dockerfile
           push: true
           sbom: true
-          provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             ${{ steps.meta.outputs.labels }}

--- a/config/ci/compare-web-bundle-size.sh
+++ b/config/ci/compare-web-bundle-size.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_file="${1:-base-bundle-size.json}"
+pr_file="${2:-pr-bundle-size.json}"
+output_file="${3:-bundle-size-comment.md}"
+
+bun -e "
+const base = JSON.parse(await Bun.file(process.argv[1]).text())
+const pr = JSON.parse(await Bun.file(process.argv[2]).text())
+const out = process.argv[3]
+
+function formatBytes(bytes) {
+	const units = ['B', 'KB', 'MB']
+	let value = bytes
+	let unit = 0
+	while (value >= 1024 && unit < units.length - 1) {
+		value /= 1024
+		unit++
+	}
+	return \`\${value.toFixed(unit === 0 ? 0 : 2)} \${units[unit]}\`
+}
+
+function diffLine(label, baseBytes, prBytes) {
+	const delta = prBytes - baseBytes
+	const deltaSign = delta >= 0 ? '+' : '-'
+	const pct = baseBytes === 0 ? 'n/a' : \`\${deltaSign}\${Math.abs((delta / baseBytes) * 100).toFixed(2)}%\`
+	return \`| \${label} | \${formatBytes(baseBytes)} | \${formatBytes(prBytes)} | \${deltaSign}\${formatBytes(Math.abs(delta))} (\${pct}) |\`
+}
+
+const body = [
+	'<!-- web-bundle-size -->',
+	'### Web bundle size',
+	'',
+	'Comparison against \`main\` after \`expo export -p web\` (Atlas enabled).',
+	'',
+	'| Asset | main | PR | Diff |',
+	'| --- | --- | --- | --- |',
+	diffLine('JavaScript', base.js_bytes, pr.js_bytes),
+	diffLine('CSS', base.css_bytes, pr.css_bytes),
+	diffLine('Total', base.total_bytes, pr.total_bytes),
+	'',
+].join('\n')
+
+await Bun.write(out, body)
+" "$base_file" "$pr_file" "$output_file"
+
+cat "$output_file"

--- a/config/ci/measure-web-bundle.sh
+++ b/config/ci/measure-web-bundle.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file="${1:-bundle-size.json}"
+
+bun run licences:bundle
+EXPO_UNSTABLE_ATLAS=true npx expo export -p web -c
+
+js_bytes=0
+css_bytes=0
+
+if [ -d dist/_expo/static/js ]; then
+	js_bytes=$(find dist/_expo/static/js -type f -name '*.js' -printf '%s\n' | awk '{s+=$1} END {print s+0}')
+fi
+
+if [ -d dist/_expo/static/css ]; then
+	css_bytes=$(find dist/_expo/static/css -type f -name '*.css' -printf '%s\n' | awk '{s+=$1} END {print s+0}')
+fi
+
+total_bytes=$((js_bytes + css_bytes))
+
+printf '{"js_bytes":%s,"css_bytes":%s,"total_bytes":%s}\n' "$js_bytes" "$css_bytes" "$total_bytes" >"$output_file"
+echo "Web bundle sizes — JS: ${js_bytes} bytes, CSS: ${css_bytes} bytes, total: ${total_bytes} bytes"

--- a/config/ci/web-export-env.sh
+++ b/config/ci/web-export-env.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Public build-time env vars for CI web exports (matches Docker build args).
+export EXPO_PUBLIC_THI_API_KEY="${EXPO_PUBLIC_THI_API_KEY:-ci-placeholder}"
+export EXPO_PUBLIC_NEULAND_GRAPHQL_ENDPOINT="${EXPO_PUBLIC_NEULAND_GRAPHQL_ENDPOINT:-https://api.neuland.app/graphql}"
+export EXPO_PUBLIC_APTABASE_KEY="${EXPO_PUBLIC_APTABASE_KEY:-}"
+export EXPO_PUBLIC_FLIPT_URL="${EXPO_PUBLIC_FLIPT_URL:-https://flipt.neuland.ing}"
+export EXPO_PUBLIC_FLIPT_NAMESPACE="${EXPO_PUBLIC_FLIPT_NAMESPACE:-neuland-app}"
+export EXPO_PUBLIC_GIT_COMMIT_HASH="${EXPO_PUBLIC_GIT_COMMIT_HASH:-${GITHUB_SHA:-local}}"

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -7,8 +7,6 @@ import { useTransparentHeaderStyle } from '@/hooks/useTransparentHeader'
 import i18n from '@/localization/i18n'
 import { getPlatformHeaderButtons } from '@/utils/header-buttons'
 import '@/styles/unistyles'
-
-// CI: touch src to exercise path-filtered web and Android checks
 import { getLocales } from 'expo-localization'
 import { useQuickActionRouting } from 'expo-quick-actions/router'
 import { type Href, router, Stack } from 'expo-router'

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -7,6 +7,8 @@ import { useTransparentHeaderStyle } from '@/hooks/useTransparentHeader'
 import i18n from '@/localization/i18n'
 import { getPlatformHeaderButtons } from '@/utils/header-buttons'
 import '@/styles/unistyles'
+
+// CI: touch src to exercise path-filtered web and Android checks
 import { getLocales } from 'expo-localization'
 import { useQuickActionRouting } from 'expo-quick-actions/router'
 import { type Href, router, Stack } from 'expo-router'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Expands CI/CD coverage for web and Android PRs and hardens Docker release builds.

### Shared setup composite action
- Adds `.github/actions/setup` for checkout (LFS), Bun with cache, and `bun install --frozen-lockfile`
- Refactors `ci.yml` jobs and `release.yml` publish step to use it

### Web (PR + main)
- **Path-filtered jobs** when `src/**`, `*.web.tsx`, or web config changes
- **Web export smoke test** on `main` / merge queue via `config/ci/measure-web-bundle.sh`
- **Bundle size regression** on PRs: exports `main` + PR head with Atlas enabled, posts/updates a sticky PR comment comparing JS/CSS/total sizes

### Android (PR)
- New `android-pr-check.yml` runs when Android paths change **or** the PR has the `android` label
- Runs `prebuild:android` + `./gradlew assembleDebug` with JDK 17 and Android SDK

### Docker (staging + release)
- Adds Buildx and **SBOM** (`sbom: true`) to GHCR pushes

### Misc fixes
- CI concurrency group cancels stale runs on new pushes
- Aligns `publish-android` to `--frozen-lockfile` via composite action
- Removes duplicate `prebuild:android` step in Android release/beta workflows
- Fixes `dorny/paths-filter` action pin to the correct v3.0.2 SHA

## Notes
- PR web bundle size job performs two exports and may take several minutes on web-touching PRs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-698b806e-fcd5-4c7e-85fb-ddf8193c3744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-698b806e-fcd5-4c7e-85fb-ddf8193c3744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

