### PR TITLE
fix: use correct setup-buildx-action SHA for v3.11.0

### DIFF
--- a/.github/workflows/build-webapp.yml
+++ b/.github/workflows/build-webapp.yml
@@ -34,7 +34,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171bb1face5a8a351bf1b4576c3934bced28 # v3.11.0
+        uses: docker/setup-buildx-action@18ce135bb5112fa8ce4ed6c17ab05699d7f3a5e0 # v3.11.0
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171bb1face5a8a351bf1b4576c3934bced28 # v3.11.0
+        uses: docker/setup-buildx-action@18ce135bb5112fa8ce4ed6c17ab05699d7f3a5e0 # v3.11.0
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes failing `build-and-push-image` on `main` after #460 merged.

The pinned commit `e468171bb1face5a8a351bf1b4576c3934bced28` does not exist on `docker/setup-buildx-action`. Updated both Docker workflows to the correct **v3.11.0** SHA: `18ce135bb5112fa8ce4ed6c17ab05699d7f3a5e0`.

## Affected workflows
- `.github/workflows/build-webapp.yml`
- `.github/workflows/release.yml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-698b806e-fcd5-4c7e-85fb-ddf8193c3744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-698b806e-fcd5-4c7e-85fb-ddf8193c3744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

