### PR TITLE
fix: upload APK before publishing immutable GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           name: ${{ github.ref_name }}
           body: ${{ steps.git-cliff.outputs.content }}
           prerelease: ${{ env.PRERELEASE }}
-          draft: false
+          draft: true
 
   build-docker-image:
     name: Build and publish Docker image
@@ -271,5 +271,12 @@ jobs:
                 'Content-Type': 'application/vnd.android.package-archive'
               }
             });
+
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              draft: false
+            });
             
-            console.log(`Successfully uploaded ${assetName} to release ${release.id}`);
+            console.log(`Successfully uploaded ${assetName} and published release ${release.id}`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes `Cannot upload assets to an immutable release` when attaching the Android APK after tag releases.

The repo has **immutable releases** enabled. Once a release is published, assets cannot be added. The workflow previously created the GitHub release immediately (`draft: false`) in the `changelog` job, then tried to upload the APK later in `create-apk-release` — after immutability had already locked the release.

## Fix
1. Create the GitHub release as a **draft** in `changelog`
2. Upload the APK to the draft release in `create-apk-release`
3. **Publish** the release (`draft: false`) after the asset upload succeeds

This matches GitHub’s recommended flow for immutable releases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-698b806e-fcd5-4c7e-85fb-ddf8193c3744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-698b806e-fcd5-4c7e-85fb-ddf8193c3744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

