### PR TITLE
ci: add EAS Update preview workflow for pull requests

### DIFF
--- a/.github/workflows/eas-pr-preview.yml
+++ b/.github/workflows/eas-pr-preview.yml
@@ -1,0 +1,49 @@
+name: EAS PR preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: eas-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Publish EAS Update preview
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      EXPO_PUBLIC_THI_API_KEY: ${{ secrets.EXPO_PUBLIC_THI_API_KEY }}
+      EXPO_PUBLIC_NEULAND_GRAPHQL_ENDPOINT: ${{ vars.GRAPHQL_ENDPOINT_DEV }}
+      EXPO_PUBLIC_APTABASE_KEY: ${{ secrets.EXPO_PUBLIC_APTABASE_KEY }}
+      EXPO_PUBLIC_FLIPT_URL: https://flipt.neuland.ing
+      EXPO_PUBLIC_FLIPT_NAMESPACE: neuland-app
+      EXPO_PUBLIC_GIT_COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Check for EXPO_TOKEN
+        run: |
+          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
+            echo "EXPO_TOKEN is required for EAS Update previews. Add it in repository secrets."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          lfs: true
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/setup
+
+      - uses: ./.github/actions/setup-eas
+        with:
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Create preview
+        uses: expo/expo-github-action/preview@eab7a230208c952974db8c3245cfd78402c7b385 # v9.0.0
+        with:
+          command: eas update --auto --branch ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/eas-pr-preview.yml
+++ b/.github/workflows/eas-pr-preview.yml
@@ -9,6 +9,14 @@ concurrency:
   group: eas-preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  EXPO_PUBLIC_THI_API_KEY: ${{ secrets.EXPO_PUBLIC_THI_API_KEY }}
+  EXPO_PUBLIC_NEULAND_GRAPHQL_ENDPOINT: ${{ vars.GRAPHQL_ENDPOINT_DEV }}
+  EXPO_PUBLIC_APTABASE_KEY: ${{ secrets.EXPO_PUBLIC_APTABASE_KEY }}
+  EXPO_PUBLIC_FLIPT_URL: https://flipt.neuland.ing
+  EXPO_PUBLIC_FLIPT_NAMESPACE: neuland-app
+  EXPO_PUBLIC_GIT_COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
+
 jobs:
   preview:
     name: Publish EAS Update preview
@@ -16,13 +24,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    env:
-      EXPO_PUBLIC_THI_API_KEY: ${{ secrets.EXPO_PUBLIC_THI_API_KEY }}
-      EXPO_PUBLIC_NEULAND_GRAPHQL_ENDPOINT: ${{ vars.GRAPHQL_ENDPOINT_DEV }}
-      EXPO_PUBLIC_APTABASE_KEY: ${{ secrets.EXPO_PUBLIC_APTABASE_KEY }}
-      EXPO_PUBLIC_FLIPT_URL: https://flipt.neuland.ing
-      EXPO_PUBLIC_FLIPT_NAMESPACE: neuland-app
-      EXPO_PUBLIC_GIT_COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
     steps:
       - name: Check for EXPO_TOKEN
         run: |
@@ -49,3 +50,79 @@ jobs:
         uses: expo/expo-github-action/preview@eab7a230208c952974db8c3245cfd78402c7b385 # v9.0.0
         with:
           command: eas update --auto --branch ${{ github.event.pull_request.head.ref }}
+
+  web-preview:
+    name: Deploy web preview
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check for EXPO_TOKEN
+        run: |
+          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
+            echo "EXPO_TOKEN is required for EAS Hosting previews. Add it in repository secrets."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          lfs: true
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/setup
+
+      - uses: ./.github/actions/setup-eas
+        with:
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Export web
+        run: |
+          source config/ci/web-export-env.sh
+          bun run licences:bundle
+          bunx expo export -p web -c
+
+      - name: Deploy to EAS Hosting
+        id: deploy
+        run: |
+          eas deploy --non-interactive --json --alias "pr-${{ github.event.pull_request.number }}" > deploy.json
+          echo "preview_url=$(jq -r '.aliases[0].url // .url' deploy.json)" >> "$GITHUB_OUTPUT"
+          echo "dashboard_url=$(jq -r '.dashboardUrl' deploy.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment web preview URL
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const marker = '<!-- eas-web-preview -->'
+            const url = '${{ steps.deploy.outputs.preview_url }}'
+            const dashboard = '${{ steps.deploy.outputs.dashboard_url }}'
+            const body = [
+              marker,
+              '## Web preview (EAS Hosting)',
+              '',
+              `Preview this PR in the browser: [${url}](${url})`,
+              '',
+              `[View deployment in Expo dashboard](${dashboard})`,
+            ].join('\n')
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const existing = comments.find((comment) => comment.body?.includes(marker))
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+              return
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            })

--- a/.github/workflows/eas-pr-preview.yml
+++ b/.github/workflows/eas-pr-preview.yml
@@ -44,6 +44,8 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Create preview
+        # Publishes to an EAS branch named after the PR — isolated from production.
+        # Requires a dev client build; does not OTA-update App Store / Play Store users.
         uses: expo/expo-github-action/preview@eab7a230208c952974db8c3245cfd78402c7b385 # v9.0.0
         with:
           command: eas update --auto --branch ${{ github.event.pull_request.head.ref }}

--- a/app.config.json
+++ b/app.config.json
@@ -5,6 +5,12 @@
 		"scheme": "neuland",
 		"owner": "neuland-ingolstadt",
 		"version": "0.16.0",
+		"runtimeVersion": {
+			"policy": "appVersion"
+		},
+		"updates": {
+			"url": "https://u.expo.dev/b0ef9e3f-3115-44b0-abc7-99dd75821353"
+		},
 		"orientation": "portrait",
 		"githubUrl": "https://github.com/neuland-ingolstadt/neuland.app-native/",
 		"userInterfaceStyle": "automatic",

--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
         "expo-splash-screen": "~31.0.13",
         "expo-symbols": "~1.0.8",
         "expo-system-ui": "~6.0.9",
+        "expo-updates": "~29.0.18",
         "fuse.js": "^7.4.2",
         "graphql": "^17.0.1",
         "i18next": "26.3.1",
@@ -1216,6 +1217,8 @@
 
     "expo-dev-menu-interface": ["expo-dev-menu-interface@2.0.0", "", { "peerDependencies": { "expo": "*" } }, "sha512-BvAMPt6x+vyXpThsyjjOYyjwfjREV4OOpQkZ0tNl+nGpsPfcY9mc6DRACoWnH9KpLzyIt3BOgh3cuy/h/OxQjw=="],
 
+    "expo-eas-client": ["expo-eas-client@1.0.8", "", {}, "sha512-5or11NJhSeDoHHI6zyvQDW2cz/yFyE+1Cz8NTs5NK8JzC7J0JrkUgptWtxyfB6Xs/21YRNifd3qgbBN3hfKVgA=="],
+
     "expo-file-system": ["expo-file-system@19.0.23", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-MeGkid9OeNILfT/qonaXHp4f2c15xaB28U/bcN7pqZej0Kx0+6+V7e9ZIXpPHm07zVatxA+QkMTPQEGfmvVOxA=="],
 
     "expo-font": ["expo-font@14.0.12", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-QQzunE2Mxk45AsCWm3tK7OpVljbtVnKD58q4/qliev+cbye1IOduUnRIdD+P7DyButw17G9MTX795kgaQiz5hQ=="],
@@ -1252,9 +1255,13 @@
 
     "expo-splash-screen": ["expo-splash-screen@31.0.13", "", { "dependencies": { "@expo/prebuild-config": "^54.0.8" }, "peerDependencies": { "expo": "*" } }, "sha512-1epJLC1cDlwwj089R2h8cxaU5uk4ONVAC+vzGiTZH4YARQhL4Stlz1MbR6yAS173GMosvkE6CAeihR7oIbCkDA=="],
 
+    "expo-structured-headers": ["expo-structured-headers@5.0.0", "", {}, "sha512-RmrBtnSphk5REmZGV+lcdgdpxyzio5rJw8CXviHE6qH5pKQQ83fhMEcigvrkBdsn2Efw2EODp4Yxl1/fqMvOZw=="],
+
     "expo-symbols": ["expo-symbols@1.0.8", "", { "dependencies": { "sf-symbols-typescript": "^2.0.0" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-7bNjK350PaQgxBf0owpmSYkdZIpdYYmaPttDBb2WIp6rIKtcEtdzdfmhsc2fTmjBURHYkg36+eCxBFXO25/1hw=="],
 
     "expo-system-ui": ["expo-system-ui@6.0.9", "", { "dependencies": { "@react-native/normalize-colors": "0.81.5", "debug": "^4.3.2" }, "peerDependencies": { "expo": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-eQTYGzw1V4RYiYHL9xDLYID3Wsec2aZS+ypEssmF64D38aDrqbDgz1a2MSlHLQp2jHXSs3FvojhZ9FVela1Zcg=="],
+
+    "expo-updates": ["expo-updates@29.0.18", "", { "dependencies": { "@expo/code-signing-certificates": "^0.0.6", "@expo/plist": "^0.4.9", "@expo/spawn-async": "^1.7.2", "arg": "4.1.0", "chalk": "^4.1.2", "debug": "^4.3.4", "expo-eas-client": "~1.0.8", "expo-manifests": "~1.0.11", "expo-structured-headers": "~5.0.0", "expo-updates-interface": "~2.0.0", "getenv": "^2.0.0", "glob": "^13.0.0", "ignore": "^5.3.1", "resolve-from": "^5.0.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" }, "bin": { "expo-updates": "bin/cli.js" } }, "sha512-qn0YDM7wVwghQAaxb9NYzzwrmj+v8Djz5H+Zft4/myG9SPg4ICAfDy52IVF0K+/GH/oNgsFfzmmLl6hIkDu42g=="],
 
     "expo-updates-interface": ["expo-updates-interface@2.0.0", "", { "peerDependencies": { "expo": "*" } }, "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg=="],
 
@@ -2563,6 +2570,10 @@
     "expo-modules-autolinking/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
     "expo-router/semver": ["semver@7.6.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
+
+    "expo-updates/arg": ["arg@4.1.0", "", {}, "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="],
+
+    "expo-updates/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "express/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
 		"expo-splash-screen": "~31.0.13",
 		"expo-symbols": "~1.0.8",
 		"expo-system-ui": "~6.0.9",
+		"expo-updates": "~29.0.18",
 		"fuse.js": "^7.4.2",
 		"graphql": "^17.0.1",
 		"i18next": "26.3.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a new GitHub Actions workflow that publishes an EAS Update preview on every pull request to `main`, following the [Expo PR preview guide](https://docs.expo.dev/eas-update/github-actions/).

The workflow matches the existing CI setup:

- Pinned `actions/checkout@v7` with Git LFS and the PR head SHA
- Composite `./.github/actions/setup` (Node 26, Bun, frozen lockfile install)
- Composite `./.github/actions/setup-eas` (`expo/expo-github-action@v9.0.0`)
- `expo/expo-github-action/preview@v9.0.0` with `eas update --auto --branch ${{ github.event.pull_request.head.ref }}`
- Dev build-time `EXPO_PUBLIC_*` env vars aligned with other CI jobs (`GRAPHQL_ENDPOINT_DEV`, etc.)
- Concurrency group per PR with cancel-in-progress
- `pull-requests: write` permission so the preview action can comment with QR codes

## Checklist

- [ ] `EXPO_TOKEN` is configured in repository secrets (workflow fails fast if missing)
- [ ] EAS Update is enabled for the Expo project (requires `expo-updates` + update config if not already set up)

## Additional notes

The preview branch name uses `github.event.pull_request.head.ref` so updates are not tied to GitHub's temporary merge ref.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28955862-d127-4b68-87fa-eae40fe7aa0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28955862-d127-4b68-87fa-eae40fe7aa0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

