### PR TITLE
chore: add project MCP config for Outline and Expo docs

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,12 @@
+{
+	"mcpServers": {
+		"neuland-outline": {
+			"url": "https://outline.neuland.ing/mcp"
+		},
+		"expo-docs": {
+			"type": "stdio",
+			"command": "npx",
+			"args": ["-y", "expo-local-docs-mcp"]
+		}
+	}
+}

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -3,10 +3,11 @@
 		"neuland-outline": {
 			"url": "https://outline.neuland.ing/mcp"
 		},
-		"expo-docs": {
-			"type": "stdio",
-			"command": "npx",
-			"args": ["-y", "expo-local-docs-mcp"]
+		"expo": {
+			"url": "https://mcp.expo.dev/mcp"
+		},
+		"uniwind": {
+			"url": "https://docs.uniwind.dev/mcp"
 		}
 	}
 }

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,6 @@
+# Optional: Outline API key for Cursor MCP (see AGENTS.md → Cursor MCP)
+# OUTLINE_API_KEY="ol_api_..."
+
 EXPO_PUBLIC_THI_API_KEY="abc123"
 EXPO_PUBLIC_NEULAND_AUTHENTIK_CLIENT_ID="your-authentik-client-id"
 EXPO_PUBLIC_OFFICE_PRESENCE_ENDPOINT="https://office-presence-api.neuland.app"

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,3 @@
-# Optional: Outline API key for Cursor MCP (see AGENTS.md → Cursor MCP)
-# OUTLINE_API_KEY="ol_api_..."
-
 EXPO_PUBLIC_THI_API_KEY="abc123"
 EXPO_PUBLIC_NEULAND_AUTHENTIK_CLIENT_ID="your-authentik-client-id"
 EXPO_PUBLIC_OFFICE_PRESENCE_ENDPOINT="https://office-presence-api.neuland.app"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,11 +81,14 @@ Project MCP servers live in `.cursor/mcp.json` and load automatically when you o
 | Server | Purpose | Auth |
 | --- | --- | --- |
 | `neuland-outline` | Search, read, and edit Neuland's [Outline](https://outline.neuland.ing) workspace (setup guides, architecture docs, …) | OAuth on first connect (Cursor Settings → MCP). Workspace admins can disable MCP under Outline → Settings → AI. |
-| `expo-docs` | Offline search of bundled Expo SDK documentation (`search_expo_docs`, `get_expo_api_reference`, …) | None |
+| `expo` | Official [Expo MCP](https://docs.expo.dev/mcp/): live SDK docs, `expo install`, EAS builds/workflows, TestFlight crashes | Expo OAuth on first connect (free tier includes monthly usage) |
+| `uniwind` | [Uniwind](https://docs.uniwind.dev/mcp) docs search and API reference (`search_uniwind`, virtual docs filesystem) | None |
 
-After cloning, open **Cursor Settings → MCP** and confirm both servers show as connected. Toggle them off and on, or reload the window, if they do not appear immediately.
+After cloning, open **Cursor Settings → MCP** and confirm all servers show as connected. Toggle them off and on, or reload the window, if they do not appear immediately.
 
-**API key auth (optional):** If OAuth is unavailable, generate a token at [outline.neuland.ing/settings/tokens](https://outline.neuland.ing/settings/tokens), add `OUTLINE_API_KEY` to `.env.local`, and extend the `neuland-outline` entry with `"headers": { "Authorization": "Bearer ${env:OUTLINE_API_KEY}" }`.
+**Outline API key auth (optional):** If OAuth is unavailable, generate a token at [outline.neuland.ing/settings/tokens](https://outline.neuland.ing/settings/tokens), add `OUTLINE_API_KEY` to `.env.local`, and extend the `neuland-outline` entry with `"headers": { "Authorization": "Bearer ${env:OUTLINE_API_KEY}" }`.
+
+**Expo local capabilities (optional):** For simulator screenshots, UI automation, DevTools, and `expo-router` sitemap introspection, install `expo-mcp` as a dev dependency and start Metro with `EXPO_UNSTABLE_MCP_SERVER=1 bun dev`. Reconnect the `expo` MCP server after starting or stopping the dev server. See the [Expo MCP docs](https://docs.expo.dev/mcp/) for details.
 
 Release / tooling scripts (rarely needed during day-to-day dev — usually CI or a release
 maintainer runs these):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,9 +84,7 @@ Project MCP servers live in `.cursor/mcp.json` and load automatically when you o
 | `expo` | Official [Expo MCP](https://docs.expo.dev/mcp/): live SDK docs, `expo install`, EAS builds/workflows, TestFlight crashes | Expo OAuth on first connect (free tier includes monthly usage) |
 | `uniwind` | [Uniwind](https://docs.uniwind.dev/mcp) docs search and API reference (`search_uniwind`, virtual docs filesystem) | None |
 
-After cloning, open **Cursor Settings → MCP** and confirm all servers show as connected. Toggle them off and on, or reload the window, if they do not appear immediately.
-
-**Outline API key auth (optional):** If OAuth is unavailable, generate a token at [outline.neuland.ing/settings/tokens](https://outline.neuland.ing/settings/tokens), add `OUTLINE_API_KEY` to `.env.local`, and extend the `neuland-outline` entry with `"headers": { "Authorization": "Bearer ${env:OUTLINE_API_KEY}" }`.
+After cloning, open **Cursor Settings → MCP** and confirm all servers show as connected. Toggle them off and on, or reload the window, if they do not appear immediately. Connect `neuland-outline` and `expo` via OAuth when prompted.
 
 **Expo local capabilities (optional):** For simulator screenshots, UI automation, DevTools, and `expo-router` sitemap introspection, install `expo-mcp` as a dev dependency and start Metro with `EXPO_UNSTABLE_MCP_SERVER=1 bun dev`. Reconnect the `expo` MCP server after starting or stopping the dev server. See the [Expo MCP docs](https://docs.expo.dev/mcp/) for details.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,19 @@ bun pkgs                     # `expo install --check` for SDK-compatible deps
 bun uniwind:types            # regenerate src/uniwind-types.d.ts after global.css changes
 ```
 
+### Cursor MCP
+
+Project MCP servers live in `.cursor/mcp.json` and load automatically when you open the repo in Cursor.
+
+| Server | Purpose | Auth |
+| --- | --- | --- |
+| `neuland-outline` | Search, read, and edit Neuland's [Outline](https://outline.neuland.ing) workspace (setup guides, architecture docs, …) | OAuth on first connect (Cursor Settings → MCP). Workspace admins can disable MCP under Outline → Settings → AI. |
+| `expo-docs` | Offline search of bundled Expo SDK documentation (`search_expo_docs`, `get_expo_api_reference`, …) | None |
+
+After cloning, open **Cursor Settings → MCP** and confirm both servers show as connected. Toggle them off and on, or reload the window, if they do not appear immediately.
+
+**API key auth (optional):** If OAuth is unavailable, generate a token at [outline.neuland.ing/settings/tokens](https://outline.neuland.ing/settings/tokens), add `OUTLINE_API_KEY` to `.env.local`, and extend the `neuland-outline` entry with `"headers": { "Authorization": "Bearer ${env:OUTLINE_API_KEY}" }`.
+
 Release / tooling scripts (rarely needed during day-to-day dev — usually CI or a release
 maintainer runs these):
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📋 Description

Adds shared Cursor MCP configuration so contributors get the same AI tooling on clone.

- **`.cursor/mcp.json`** — project-level MCP servers:
  - `neuland-outline` — Outline MCP at `https://outline.neuland.ing/mcp` (OAuth)
  - `expo` — official [Expo MCP](https://docs.expo.dev/mcp/) at `https://mcp.expo.dev/mcp` (OAuth)
  - `uniwind` — [Uniwind docs MCP](https://docs.uniwind.dev/mcp) (no auth)
- **`AGENTS.md`** — "Cursor MCP" section with OAuth setup and optional Expo local capabilities

## ✅ Checklist

- [ ] I've tested my changes on iOS
- [ ] I've tested my changes on Android
- [ ] I've tested my changes on Web
- [x] I've added or updated documentation (if needed)
- [ ] I've reviewed the related issues, if any

## 🗒️ Additional Notes

No runtime app changes — config/docs only. `neuland-outline` and `expo` authenticate via OAuth in Cursor Settings → MCP. Optional simulator automation needs `expo-mcp` + `EXPO_UNSTABLE_MCP_SERVER=1 bun dev` (documented in AGENTS.md).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f145d-2fe9-782f-b6dd-8dabc7dd7e9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f145d-2fe9-782f-b6dd-8dabc7dd7e9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

