### PR TITLE
fix: adjust flex properties for wideBox and narrowBox

### DIFF
--- a/src/components/Settings/student-info-section.tsx
+++ b/src/components/Settings/student-info-section.tsx
@@ -83,9 +83,9 @@ const stylesheet = createStyleSheet(() => ({
 		marginBottom: 10
 	},
 	wideBox: {
-		flex: 2
+		flex: 5
 	},
 	narrowBox: {
-		flex: 1
+		flex: 3
 	}
 }))


### PR DESCRIPTION
## 📋 Description

Improve flex properties to fix wrapping text

Before/After:

<img width="auto" height="400" alt="Simulator Screenshot - iPhone 15 Pro - 26 5 - 2026-06-30 at 13 52 39" src="https://github.com/user-attachments/assets/1c200206-44f0-421d-991e-dec05f97d0ed" />

<img width="auto" height="400" alt="Simulator Screenshot - iPhone 15 Pro - 26 5 - 2026-06-30 at 13 52 47" src="https://github.com/user-attachments/assets/f951897d-bf64-43bd-bf2d-433c5242c2ec" />



## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web
- [ ] I’ve added or updated documentation (if needed)
- [ ] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

<!-- Anything else reviewers should be aware of? -->
