### PR TITLE
fix(android): raise Gradle JVM metaspace for release builds

### DIFF
--- a/app.config.json
+++ b/app.config.json
@@ -252,6 +252,7 @@
 			],
 			"./config/plugins/withIosCiArtifacts.js",
 			"./config/plugins/withCiScriptsSymlink.js",
+			"./config/plugins/withGradleJvmArgs.js",
 			"./config/plugins/withXcode26FmtWorkaround.js",
 			[
 				"expo-font",

--- a/config/plugins/withGradleJvmArgs.js
+++ b/config/plugins/withGradleJvmArgs.js
@@ -1,0 +1,27 @@
+const { withGradleProperties } = require('expo/config-plugins')
+
+const GRADLE_JVM_ARGS_KEY = 'org.gradle.jvmargs'
+const GRADLE_JVM_ARGS_VALUE =
+	'-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+HeapDumpOnOutOfMemoryError'
+
+function withGradleJvmArgs(expoConfig) {
+	return withGradleProperties(expoConfig, (config) => {
+		const index = config.modResults.findIndex(
+			(item) => item.type === 'property' && item.key === GRADLE_JVM_ARGS_KEY
+		)
+
+		if (index >= 0) {
+			config.modResults[index].value = GRADLE_JVM_ARGS_VALUE
+		} else {
+			config.modResults.push({
+				type: 'property',
+				key: GRADLE_JVM_ARGS_KEY,
+				value: GRADLE_JVM_ARGS_VALUE
+			})
+		}
+
+		return config
+	})
+}
+
+module.exports = withGradleJvmArgs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The **Release** workflow's `Build Android app` job has been failing intermittently on tag builds. The most recent failure (`0.16.0-beta.12`, [run #28418741006](https://github.com/neuland-ingolstadt/neuland.app-native/actions/runs/28418741006)) died during `eas build --local` in the Gradle `lintVitalAnalyzeRelease` phase:

```
Execution failed for task ':expo-constants:lintVitalAnalyzeRelease'.
> Message: Metaspace
> Stack: OutOfMemoryError
```

Gradle warned earlier in the same build:

> The currently configured max heap space is '2 GiB' and the configured max metaspace is '512 MiB'.

The previous successful release (`0.16.0-beta.11`) logged the same Metaspace warning but completed — this is a flaky OOM at the default Expo prebuild limits, not a code regression.

## Root cause

Expo prebuild generates `android/gradle.properties` with:

```
org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
```

Release builds lint many native modules (`expo`, `expo-constants`, `react-native-reanimated`, `react-native-mmkv`, …). Android Lint's Kotlin/UAST analysis is metaspace-heavy and can exhaust 512 MiB before the daemon restarts.

## Fix

Add `config/plugins/withGradleJvmArgs.js` and register it in `app.config.json` to raise limits during prebuild:

- Heap: 2 GiB → 4 GiB
- Metaspace: 512 MiB → 1 GiB

This applies consistently to local `bun build:android`, CI `android-prepare`, and EAS local builds.

## Historical context (already addressed)

Several earlier Release workflow failures were **not** Android compile errors:

| Tag | Android build | Actual failure |
|-----|---------------|----------------|
| beta.5–beta.9 | ✅ succeeded | `Publish APK to GitHub Releases` — immutable release upload (fixed in #462) |
| beta.7 | ❌ failed early | `licences` script exit 127 (fixed via `licences:bundle` in android-prepare) |

## Test plan

- [x] `bun run prebuild:android` — confirms `org.gradle.jvmargs` is patched
- [ ] Re-run Release workflow on next tag cut (or manually dispatch `Build Android (Beta)`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f19f1-9c97-756d-9133-9baeca63071f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f19f1-9c97-756d-9133-9baeca63071f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

