### PR TITLE
feat(map): update geojson overlay to v2.7 and add building L

### DIFF
--- a/src/api/neuland-api.ts
+++ b/src/api/neuland-api.ts
@@ -189,7 +189,7 @@ class NeulandAPIClient {
 	 */
 	async getMapOverlay(): Promise<FeatureCollection> {
 		return (await this.performRequest(
-			`${ASSET_ENDPOINT}/rooms_neuland_v2.6.1.geojson`
+			`${ASSET_ENDPOINT}/rooms_neuland_v2.7.geojson`
 		)) as FeatureCollection
 	}
 

--- a/src/hooks/useMapQueries.ts
+++ b/src/hooks/useMapQueries.ts
@@ -46,7 +46,7 @@ export function useMapQueries(): {
 
 	const { data: mapOverlay, error: overlayError } = useQuery<FeatureCollection>(
 		{
-			queryKey: ['mapOverlay', packageInfo.version],
+			queryKey: ['mapOverlay', packageInfo.version, 'v2.7'],
 			queryFn: async () => await NeulandAPI.getMapOverlay(),
 			staleTime: 1000 * 60 * 60 * 24 * 7, // 1 week
 			gcTime: 1000 * 60 * 60 * 24 * 60, // 60 days

--- a/src/types/asset-api.ts
+++ b/src/types/asset-api.ts
@@ -63,6 +63,7 @@ export enum Gebaeude {
 	I = 'I',
 	J = 'J',
 	K = 'K',
+	L = 'L',
 	M = 'M',
 	N = 'N',
 	P = 'P',

--- a/src/utils/map-utils.ts
+++ b/src/utils/map-utils.ts
@@ -22,6 +22,7 @@ export const BUILDINGS_IN = [
 	'I',
 	'J',
 	'K',
+	'L',
 	'M',
 	'P',
 	'X',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Updates the campus map overlay to GeoJSON v2.7 and adds building **L** to the supported buildings list.

### Changes

- Bump map overlay URL from `rooms_neuland_v2.6.1.geojson` to `rooms_neuland_v2.7.geojson` in `NeulandAPIClient.getMapOverlay()`
- Add `L` to `BUILDINGS_IN` so building L appears in room search filters and map building markers
- Add `L` to the `Gebaeude` enum for type-safe building references

## Checklist

- [ ] I've tested my changes on iOS
- [ ] I've tested my changes on Android
- [ ] I've tested my changes on Web
- [ ] I've added or updated documentation (if needed)
- [ ] I've reviewed the related issues, if any

## Additional Notes

Depends on `rooms_neuland_v2.7.geojson` being published to `https://assets.neuland.app`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2606-3198-750a-a57a-dc74884bc1c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2606-3198-750a-a57a-dc74884bc1c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

