### PR TITLE
fix: hide legal section on THI organizer info page

### DIFF
--- a/src/app/(screens)/events/organiser/[id].tsx
+++ b/src/app/(screens)/events/organiser/[id].tsx
@@ -125,20 +125,22 @@ export default function CampusLifeOrganizerScreen(): React.JSX.Element {
 	}
 
 	const statsItems: SectionGroup[] = []
-	if (organizer.registrationNumber) {
-		statsItems.push({
-			title: t('pages.event.organizerDetails.registrationNumber'),
-			value: organizer.registrationNumber
-		})
-	}
+	if (!isThiDepartmentOrganizerKind(organizerKind)) {
+		if (organizer.registrationNumber) {
+			statsItems.push({
+				title: t('pages.event.organizerDetails.registrationNumber'),
+				value: organizer.registrationNumber
+			})
+		}
 
-	if (organizer.nonProfit != null) {
-		statsItems.push({
-			title: t('pages.event.organizerDetails.nonProfit.label'),
-			value: organizer.nonProfit
-				? t('pages.event.organizerDetails.nonProfit.yes')
-				: t('pages.event.organizerDetails.nonProfit.no')
-		})
+		if (organizer.nonProfit != null) {
+			statsItems.push({
+				title: t('pages.event.organizerDetails.nonProfit.label'),
+				value: organizer.nonProfit
+					? t('pages.event.organizerDetails.nonProfit.yes')
+					: t('pages.event.organizerDetails.nonProfit.no')
+			})
+		}
 	}
 
 	const linkItems: SectionGroup[] = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📋 Description

The organizer info page (`/events/organiser/[id]`) shows a "Legal" section with registration number and non-profit status. These fields are only meaningful for campus life student associations, not for THI department organizers.

This change hides the legal section when the organizer kind is `thi_department`, using the existing `isThiDepartmentOrganizerKind` helper already used on this screen for feature-flag gating.

## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web
- [ ] I’ve added or updated documentation (if needed)
- [x] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

Campus life organizers (student associations) continue to show the legal section unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2b42-6747-708e-a16c-6aebf3a59a2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2b42-6747-708e-a16c-6aebf3a59a2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

