### PR TITLE
fix: resolve all react doctor bug findings

### DIFF
--- a/src/api/thi-session-handler.ts
+++ b/src/api/thi-session-handler.ts
@@ -66,9 +66,11 @@ export async function createSession(
 	}
 
 	storage.set('sessionCreated', Date.now().toString())
-	await saveSecureAsync('session', session)
-	await saveSecureAsync('username', modifiedUsername)
-	await saveSecureAsync('password', password)
+	await Promise.all([
+		saveSecureAsync('session', session),
+		saveSecureAsync('username', modifiedUsername),
+		saveSecureAsync('password', password)
+	])
 	return isStudent
 }
 
@@ -107,8 +109,10 @@ export async function callWithSession<T>(
 		throw new UnavailableSessionError()
 	}
 
-	let username = await loadSecureAsync('username')
-	const password = await loadSecureAsync('password')
+	let [username, password] = await Promise.all([
+		loadSecureAsync('username'),
+		loadSecureAsync('password')
+	])
 
 	if (Platform.OS === 'web') {
 		if (session === 'guest' || session == null) {

--- a/src/app/(screens)/onboarding.tsx
+++ b/src/app/(screens)/onboarding.tsx
@@ -169,7 +169,7 @@ export default function OnboardingScreen(): React.JSX.Element {
 									handlePress()
 								}
 							}}
-							key={index}
+							key={title}
 						>
 							<Animated.View style={animatedStyles}>
 								<Animated.View style={animatedStyle}>

--- a/src/components/Cards/link-card.tsx
+++ b/src/components/Cards/link-card.tsx
@@ -33,13 +33,13 @@ const LinkCard = (): React.JSX.Element => {
 	return (
 		<BaseCard title="links" onPressRoute="/links">
 			<View className="flex-row flex-wrap gap-2.5 pt-2.5">
-				{userQuicklinks.map((link, index) => {
+				{userQuicklinks.map((link) => {
 					if (link === undefined) {
 						return null
 					}
 					return (
 						<Pressable
-							key={index}
+							key={link.key}
 							onPress={() => {
 								void linkPress(link.key, link.url)
 							}}

--- a/src/components/Map/floor-picker.tsx
+++ b/src/components/Map/floor-picker.tsx
@@ -114,7 +114,7 @@ const FloorPicker = ({
 									}
 									setCurrentFloor({ floor, manual: true })
 								}}
-								key={index}
+								key={floor}
 							>
 								<View
 									className="content-center items-center self-center h-[38px] justify-center w-[38px]"

--- a/src/components/Map/free-rooms-list.tsx
+++ b/src/components/Map/free-rooms-list.tsx
@@ -20,7 +20,7 @@ export const FreeRoomsList = ({
 	return rooms !== null && rooms.length > 0 ? (
 		<View>
 			{rooms.map((room, index) => (
-				<View key={index}>
+				<View key={`${room.room}-${room.from.getTime()}`}>
 					<View className="items-center flex-row gap-[15px] justify-between px-4 py-[9px]">
 						<View>
 							<Pressable

--- a/src/components/Map/search-history.tsx
+++ b/src/components/Map/search-history.tsx
@@ -88,14 +88,13 @@ const SearchHistory = ({
 							<View className="bg-card px-3 py-[3px] w-full">
 								<ResultRow
 									result={history}
-									index={index}
 									handlePresentModalPress={handlePresentModalPress}
 									updateSearchHistory={addToSearchHistory}
 								/>
 							</View>
 						</Swipeable>
 						{index !== searchHistory.length - 1 && (
-							<Divider key={`divider-${index}`} />
+							<Divider key={`divider-${history.title}`} />
 						)}
 					</React.Fragment>
 				))}

--- a/src/components/Map/search-result-row.tsx
+++ b/src/components/Map/search-result-row.tsx
@@ -16,14 +16,12 @@ import PlatformIcon from '../Universal/icon'
 
 interface ResultRowProps {
 	result: SearchResult
-	index: number
 	handlePresentModalPress: () => void
 	updateSearchHistory: (result: SearchResult) => void
 }
 
 const ResultRow = ({
 	result,
-	index,
 	handlePresentModalPress,
 	updateSearchHistory
 }: ResultRowProps): React.JSX.Element => {
@@ -36,7 +34,6 @@ const ResultRow = ({
 	const roomTypeKey = i18n.language === 'de' ? 'Funktion_de' : 'Funktion_en'
 	return (
 		<StyledBottomSheetTouchableOpacity
-			key={index}
 			className="items-center flex-row py-2.5"
 			onPress={() => {
 				const center = result.item.properties?.center as Position | undefined

--- a/src/components/Map/search-results.tsx
+++ b/src/components/Map/search-results.tsx
@@ -111,10 +111,9 @@ const SearchResults = ({
 	}
 
 	const renderItem = useCallback(
-		({ item, index }: { item: SearchResult; index: number }) => (
+		({ item }: { item: SearchResult }) => (
 			<ResultRow
 				result={item}
-				index={index}
 				handlePresentModalPress={handlePresentModalPress}
 				updateSearchHistory={addToSearchHistory}
 			/>

--- a/src/utils/credentialStorage.ts
+++ b/src/utils/credentialStorage.ts
@@ -64,16 +64,17 @@ export default class CredentialStorage {
 		)
 		const iv = crypto.getRandomValues(new Uint8Array(12)) // AES-GCM typically uses a 12-byte IV
 
-		const encrypted = await crypto.subtle.encrypt(
-			{
-				name: 'AES-GCM',
-				iv
-			},
-			key,
-			objectToArrayBuffer(data)
-		)
-
-		const db = await this._openDatabase()
+		const [encrypted, db] = await Promise.all([
+			crypto.subtle.encrypt(
+				{
+					name: 'AES-GCM',
+					iv
+				},
+				key,
+				objectToArrayBuffer(data)
+			),
+			this._openDatabase()
+		])
 		try {
 			await db.put(STORE_NAME, { id, key, iv, encrypted })
 		} finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes all 8 React Doctor **Bugs** warnings (score improves from 75 → 80).

### Stable list keys (6)
- `components/Map/floor-picker.tsx` — `key={floor}`
- `components/Map/free-rooms-list.tsx` — `key={room.room}-${room.from.getTime()}`
- `components/Map/search-history.tsx` — divider key uses `history.title`; removed unused `index` prop from `ResultRow`
- `components/Map/search-result-row.tsx` — removed `index` prop and index-based key
- `components/Cards/link-card.tsx` — `key={link.key}`
- `app/(screens)/onboarding.tsx` — `key={title}`

### Parallel independent awaits (2)
- `api/thi-session-handler.ts` — `Promise.all` for credential reads on session refresh and credential writes on login
- `utils/credentialStorage.ts` — open IndexedDB in parallel with AES-GCM encryption

## Verification

- `bunx react-doctor@latest --directory src --verbose` — 0 Bugs warnings (was 8)
- `bun tsc --noEmit`
- `bun lint`
- `bun test` — 237 pass

## Checklist

- [ ] I've tested my changes on iOS
- [ ] I've tested my changes on Android
- [ ] I've tested my changes on Web
- [ ] I've added or updated documentation (if needed)
- [x] I've reviewed the related issues, if any

## Additional Notes

No behavior changes intended beyond faster credential I/O and safer list reconciliation when items reorder.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2b4b-d616-7de6-8abf-a1a037763376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2b4b-d616-7de6-8abf-a1a037763376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

