### PR TITLE
perf: hoist static config out of components

### DIFF
--- a/src/app/(screens)/app-icon.ios.tsx
+++ b/src/app/(screens)/app-icon.ios.tsx
@@ -35,6 +35,13 @@ iconImages = {
 
 export const appIcons = Object.keys(iconImages)
 
+const appIconCategories: Record<string, string[]> = {
+	exclusive: ['cat', 'retro'],
+	neuland: ['luxury', 'rainbowGlow', 'hacker'],
+	default: ['default', 'modernGreen', 'modernPink'],
+	rainbow: ['rainbowNeon', 'rainbowMoonLight']
+}
+
 export default function AppIconPicker(): React.JSX.Element {
 	const unlockedAppIcons = usePreferencesStore(
 		(state) => state.unlockedAppIcons
@@ -44,12 +51,6 @@ export default function AppIconPicker(): React.JSX.Element {
 	const [currentIcon, setCurrentIcon] = React.useState<string>(
 		lowercaseFirstLetter(getAppIconName() ?? 'default')
 	)
-	const categories: Record<string, string[]> = {
-		exclusive: ['cat', 'retro'],
-		neuland: ['luxury', 'rainbowGlow', 'hacker'],
-		default: ['default', 'modernGreen', 'modernPink'],
-		rainbow: ['rainbowNeon', 'rainbowMoonLight']
-	}
 	const support = supportsAlternateIcons
 	if (!support) {
 		return (
@@ -72,7 +73,7 @@ export default function AppIconPicker(): React.JSX.Element {
 				footer={t('appIcon.exclusive')}
 			>
 				<View className="content-center bg-card rounded-md justify-center">
-					{categories.exclusive.map((icon, index) => {
+					{appIconCategories.exclusive.map((icon, index) => {
 						const unlocked = unlockedAppIcons.includes(icon)
 						return (
 							<React.Fragment key={icon}>
@@ -126,7 +127,7 @@ export default function AppIconPicker(): React.JSX.Element {
 										</Text>
 									)}
 								</Pressable>
-								{index !== categories.exclusive.length - 1 && (
+								{index !== appIconCategories.exclusive.length - 1 && (
 									<Divider paddingLeft={110} />
 								)}
 							</React.Fragment>
@@ -139,7 +140,7 @@ export default function AppIconPicker(): React.JSX.Element {
 			<SectionView title={t('appIcon.categories.neuland')}>
 				<View className="content-center bg-card rounded-md justify-center">
 					{memberInfo ? (
-						categories.neuland.map((icon, index) => (
+						appIconCategories.neuland.map((icon, index) => (
 							<React.Fragment key={icon}>
 								<Pressable
 									className="items-center flex-row justify-between pe-5 ps-3 py-3"
@@ -175,7 +176,7 @@ export default function AppIconPicker(): React.JSX.Element {
 										/>
 									)}
 								</Pressable>
-								{index !== categories.neuland.length - 1 && (
+								{index !== appIconCategories.neuland.length - 1 && (
 									<Divider paddingLeft={110} />
 								)}
 							</React.Fragment>
@@ -215,7 +216,7 @@ export default function AppIconPicker(): React.JSX.Element {
 			{(['default', 'rainbow'] as const).map((key) => (
 				<SectionView title={t(`appIcon.categories.${key}`)} key={key}>
 					<View className="content-center bg-card rounded-md justify-center">
-						{categories[key].map((icon, index) => (
+						{appIconCategories[key].map((icon, index) => (
 							<React.Fragment key={icon}>
 								<Pressable
 									className="items-center flex-row justify-between pe-5 ps-3 py-3"
@@ -256,7 +257,7 @@ export default function AppIconPicker(): React.JSX.Element {
 										/>
 									)}
 								</Pressable>
-								{index !== categories[key].length - 1 && (
+								{index !== appIconCategories[key].length - 1 && (
 									<Divider paddingLeft={110} />
 								)}
 							</React.Fragment>

--- a/src/app/(screens)/food/[id].tsx
+++ b/src/app/(screens)/food/[id].tsx
@@ -52,6 +52,27 @@ import { getPlatformHeaderButtons } from '@/utils/header-buttons'
 import { copyToClipboard } from '@/utils/ui-utils'
 import { hairlineBorder, toColor } from '@/utils/uniwind-utils'
 
+const foodDataSources = {
+	IngolstadtMensa: 'https://www.werkswelt.de/?id=ingo',
+	NeuburgMensa: 'https://www.werkswelt.de/?id=mtneuburg',
+	Reimanns: 'https://reimanns.in/mittagsgerichte-wochenkarte/',
+	Canisius:
+		'https://www.canisiusstiftung.de/wp-content/uploads/Speiseplan/speiseplan.pdf'
+} as const
+
+interface FoodRestaurantLocations {
+	IngolstadtMensa: string
+	Reimanns: string
+	Canisius: string
+	[key: string]: string
+}
+
+const foodRestaurantLocations: FoodRestaurantLocations = {
+	IngolstadtMensa: 'M001',
+	Reimanns: 'F001',
+	Canisius: 'X001'
+}
+
 export default function FoodDetail(): React.JSX.Element {
 	const { id } = useLocalSearchParams<{ id: string }>()
 	const textColor = toColor(useCSSVariable('--color-text'))
@@ -78,13 +99,6 @@ export default function FoodDetail(): React.JSX.Element {
 	)
 	const { t, i18n } = useTranslation('food')
 	const { userKind = USER_GUEST } = use(UserKindContext)
-	const dataSources = {
-		IngolstadtMensa: 'https://www.werkswelt.de/?id=ingo',
-		NeuburgMensa: 'https://www.werkswelt.de/?id=mtneuburg',
-		Reimanns: 'https://reimanns.in/mittagsgerichte-wochenkarte/',
-		Canisius:
-			'https://www.canisiusstiftung.de/wp-content/uploads/Speiseplan/speiseplan.pdf'
-	}
 
 	const navigation = useNavigation()
 
@@ -183,19 +197,6 @@ export default function FoodDetail(): React.JSX.Element {
 				message={t('details.error.message')}
 			/>
 		)
-	}
-
-	interface Locations {
-		IngolstadtMensa: string
-		Reimanns: string
-		Canisius: string
-		[key: string]: string
-	}
-
-	const locations: Locations = {
-		IngolstadtMensa: 'M001',
-		Reimanns: 'F001',
-		Canisius: 'X001'
 	}
 
 	function itemAlert(item: string, itemType: 'allergen' | 'flag'): void {
@@ -405,7 +406,10 @@ export default function FoodDetail(): React.JSX.Element {
 				foodData.restaurant.slice(1)
 			: ''
 	const handlePress = (): void => {
-		const location = locations[restaurant as keyof typeof locations]
+		const location =
+			foodRestaurantLocations[
+				restaurant as keyof typeof foodRestaurantLocations
+			]
 
 		if (restaurant != null && location !== undefined) {
 			router.dismissTo({
@@ -416,7 +420,8 @@ export default function FoodDetail(): React.JSX.Element {
 	}
 
 	const locationExists =
-		restaurant !== undefined && locations[restaurant] !== undefined
+		restaurant !== undefined &&
+		foodRestaurantLocations[restaurant] !== undefined
 	const humanLocation =
 		humanLocations[restaurant as keyof typeof humanLocations]
 	const humanCategory = t(
@@ -455,8 +460,8 @@ export default function FoodDetail(): React.JSX.Element {
 					onPress: () => {
 						if (foodData?.restaurant !== null) {
 							const restaurant =
-								foodData?.restaurant as keyof typeof dataSources
-							void Linking.openURL(dataSources[restaurant])
+								foodData?.restaurant as keyof typeof foodDataSources
+							void Linking.openURL(foodDataSources[restaurant])
 						}
 					}
 				}

--- a/src/app/(screens)/grades.tsx
+++ b/src/app/(screens)/grades.tsx
@@ -37,6 +37,12 @@ function getGradeKey(grade: Grade): string {
 	return `${grade.stg}-${grade.kztn}-${grade.pon}`
 }
 
+const fuseOptions = {
+	keys: ['titel'],
+	threshold: 0.3,
+	ignoreLocation: true
+}
+
 export default function GradesSCreen(): React.JSX.Element {
 	const { t } = useTranslation('settings')
 	const textColor = toColor(useCSSVariable('--color-text'))
@@ -155,12 +161,6 @@ export default function GradesSCreen(): React.JSX.Element {
 			subscription.remove()
 		}
 	}, [])
-
-	const fuseOptions = {
-		keys: ['titel'],
-		threshold: 0.3,
-		ignoreLocation: true
-	}
 
 	const filteredGrades = React.useMemo(() => {
 		if (!grades) return null

--- a/src/components/Events/cl-sports-page.tsx
+++ b/src/components/Events/cl-sports-page.tsx
@@ -28,6 +28,8 @@ import { hairlineBorder } from '@/utils/uniwind-utils'
 import LoadingIndicator from '../Universal/loading-indicator'
 import { EmptyEventsAnimation } from './empty-events-animation'
 
+const sportsCampusLocations = ['Ingolstadt', 'Neuburg'] as const
+
 export default function ClSportsPage({
 	sportsResult
 }: {
@@ -63,7 +65,6 @@ export default function ClSportsPage({
 	}, [sportsResult.data, selectedLocation])
 
 	const { t } = useTranslation('common')
-	const locations = ['Ingolstadt', 'Neuburg']
 
 	const {
 		isRefetchingByUser: isRefetchingByUserSports,
@@ -218,7 +219,7 @@ export default function ClSportsPage({
 						{t('labels.campus')}
 					</Text>
 					<View className="flex-row items-center gap-2 pb-1 pt-2">
-						{locations.map((location) => (
+						{sportsCampusLocations.map((location) => (
 							<LocationButton location={location} key={location} />
 						))}
 					</View>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Hoists static configuration objects out of component bodies so they are not recreated on every render. This keeps stable references for memoized children and clears all 5 React Doctor `prefer-module-scope-static-value` warnings.

### Files changed

| File | Hoisted constant |
|---|---|
| `app/(screens)/app-icon.ios.tsx` | `appIconCategories` |
| `app/(screens)/food/[id].tsx` | `foodDataSources`, `foodRestaurantLocations` |
| `app/(screens)/grades.tsx` | `fuseOptions` |
| `components/Events/cl-sports-page.tsx` | `sportsCampusLocations` |

No behavior changes — pure refactor.

## Verification

- `bun tsc --noEmit`
- `bun lint`
- `bun test` — 237 pass
- React Doctor: **0** `prefer-module-scope-static-value` warnings (was 5)

## Checklist

- [ ] I've tested my changes on iOS
- [ ] I've tested my changes on Android
- [ ] I've tested my changes on Web
- [ ] I've added or updated documentation (if needed)
- [x] I've reviewed the related issues, if any
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2b4b-d616-7de6-8abf-a1a037763376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2b4b-d616-7de6-8abf-a1a037763376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

