### PR TITLE
refactor: hoist pure handlers to module scope

### DIFF
--- a/src/app/(screens)/about.tsx
+++ b/src/app/(screens)/about.tsx
@@ -39,6 +39,14 @@ import { useTransparentHeaderPadding } from '@/hooks/useTransparentHeader'
 import type { FormListSections } from '@/types/components'
 import { hairlineBorder, toColor } from '@/utils/uniwind-utils'
 
+function handleWebsitePress(): void {
+	void Linking.openURL('https://neuland-ingolstadt.de/')
+}
+
+function handleContributorsPress(): void {
+	void Linking.openURL('https://neuland.app/about/contributors')
+}
+
 export default function About(): React.JSX.Element {
 	const router = useRouter()
 	const { t } = useTranslation(['settings'])
@@ -265,15 +273,6 @@ export default function About(): React.JSX.Element {
 			pressCountRef.current = 0
 		}
 	}, [t, unlockedAppIcons, addUnlockedAppIcon])
-
-	const handleWebsitePress = (): void => {
-		void Linking.openURL('https://neuland-ingolstadt.de/')
-	}
-
-	const handleContributorsPress = (): void => {
-		const url = 'https://neuland.app/about/contributors'
-		void Linking.openURL(url)
-	}
 
 	return (
 		<ScrollView

--- a/src/components/Cards/sports-card.tsx
+++ b/src/components/Cards/sports-card.tsx
@@ -16,6 +16,24 @@ import { toColor } from '@/utils/uniwind-utils'
 import EventItem from '../Universal/event-item'
 import BaseCard from './base-card'
 
+function handleSportsItemPress(id: string): void {
+	if (Platform.OS !== 'ios') {
+		router.navigate({
+			pathname: '/events/sports/[id]',
+			params: { id }
+		})
+		return
+	}
+
+	router.navigate({
+		pathname: '/sports',
+		params: {
+			openEvent: 'true',
+			id
+		}
+	})
+}
+
 const SportsCard = (): React.JSX.Element => {
 	const primaryColor = String(toColor(useCSSVariable('--color-primary')) ?? '')
 	const { t, i18n } = useTranslation('common')
@@ -30,24 +48,6 @@ const SportsCard = (): React.JSX.Element => {
 		() => sportsByWeekday.flatMap((section) => section.data).slice(0, 2),
 		[sportsByWeekday]
 	)
-
-	const handleSportsItemPress = (id: string) => {
-		if (Platform.OS !== 'ios') {
-			router.navigate({
-				pathname: '/events/sports/[id]',
-				params: { id }
-			})
-			return
-		}
-
-		router.navigate({
-			pathname: '/sports',
-			params: {
-				openEvent: 'true',
-				id
-			}
-		})
-	}
 
 	const noData = (
 		<Text className="mt-2.5 text-text text-base font-medium">

--- a/src/components/Error/error-view.tsx
+++ b/src/components/Error/error-view.tsx
@@ -24,6 +24,22 @@ import {
 import PlatformIcon, { type LucideIcon } from '../Universal/icon'
 import StatusBox from './action-box'
 
+function handleErrorButtonPress(
+	errorTitle: string,
+	onButtonPress?: () => void
+): void {
+	switch (errorTitle) {
+		case guestError || notLoggedInError:
+			router.navigate('/login')
+			break
+		default:
+			if (onButtonPress != null) {
+				onButtonPress()
+			}
+			break
+	}
+}
+
 export default function ErrorView({
 	title,
 	message,
@@ -134,18 +150,6 @@ export default function ErrorView({
 	}
 
 	const ErrorButton = (): React.JSX.Element => {
-		const buttonAction = (): void => {
-			switch (title) {
-				case guestError || notLoggedInError:
-					router.navigate('/login')
-					break
-				default:
-					if (onButtonPress != null) {
-						onButtonPress()
-					}
-					break
-			}
-		}
 		let buttonProps = null
 
 		if (title === guestError || title === notLoggedInError) {
@@ -156,9 +160,19 @@ export default function ErrorView({
 				text: t('error.guest.button')
 			}
 		} else if (onButtonPress != null && buttonText === undefined) {
-			buttonProps = { onPress: buttonAction, text: t('error.button') }
+			buttonProps = {
+				onPress: () => {
+					handleErrorButtonPress(title, onButtonPress)
+				},
+				text: t('error.button')
+			}
 		} else if (onButtonPress != null && buttonText !== undefined) {
-			buttonProps = { onPress: buttonAction, text: buttonText }
+			buttonProps = {
+				onPress: () => {
+					handleErrorButtonPress(title, onButtonPress)
+				},
+				text: buttonText
+			}
 		}
 
 		return (buttonProps != null ||

--- a/src/components/Error/event-error-view.tsx
+++ b/src/components/Error/event-error-view.tsx
@@ -14,6 +14,39 @@ interface EventErrorViewProps {
 	message?: string
 }
 
+function getEventTypeIcon(type: string): {
+	ios: string
+	android: MaterialIcon
+	web: LucideIcon
+} {
+	switch (type) {
+		case 'clEvents':
+			return {
+				ios: 'calendar',
+				android: 'calendar_month' satisfies MaterialIcon,
+				web: 'Calendar' satisfies LucideIcon
+			}
+		case 'thiEvents':
+			return {
+				ios: 'building.columns.fill',
+				android: 'account_balance' satisfies MaterialIcon,
+				web: 'Building2' satisfies LucideIcon
+			}
+		case 'sports':
+			return {
+				ios: 'figure.run',
+				android: 'directions_run' satisfies MaterialIcon,
+				web: 'Volleyball' satisfies LucideIcon
+			}
+		default:
+			return {
+				ios: 'calendar',
+				android: 'calendar_month' satisfies MaterialIcon,
+				web: 'Calendar' satisfies LucideIcon
+			}
+	}
+}
+
 export function EventErrorView({
 	eventType,
 	title,
@@ -21,35 +54,6 @@ export function EventErrorView({
 }: EventErrorViewProps): React.JSX.Element {
 	const primaryColor = useCSSVariable('--color-primary')
 	const { t } = useTranslation(['common', 'navigation'])
-
-	const getEventTypeIcon = (type: string) => {
-		switch (type) {
-			case 'clEvents':
-				return {
-					ios: 'calendar',
-					android: 'calendar_month' satisfies MaterialIcon,
-					web: 'Calendar' satisfies LucideIcon
-				}
-			case 'thiEvents':
-				return {
-					ios: 'building.columns.fill',
-					android: 'account_balance' satisfies MaterialIcon,
-					web: 'Building2' satisfies LucideIcon
-				}
-			case 'sports':
-				return {
-					ios: 'figure.run',
-					android: 'directions_run' satisfies MaterialIcon,
-					web: 'Volleyball' satisfies LucideIcon
-				}
-			default:
-				return {
-					ios: 'calendar',
-					android: 'calendar_month' satisfies MaterialIcon,
-					web: 'Calendar' satisfies LucideIcon
-				}
-		}
-	}
 
 	const getEventTypeTitle = (type: string): string => {
 		switch (type) {

--- a/src/components/Events/calendar-animation.tsx
+++ b/src/components/Events/calendar-animation.tsx
@@ -21,6 +21,16 @@ import PlatformIcon from '@/components/Universal/icon'
 import type { MaterialIcon } from '@/types/material-icons'
 import { toColor } from '@/utils/uniwind-utils'
 
+function triggerSuperLightHaptic(): void {
+	if (Platform.OS === 'ios') {
+		void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
+	}
+}
+
+function triggerCalendarAnimationHaptic(): void {
+	void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
+}
+
 interface CalendarAnimationProps {
 	size?: number
 }
@@ -83,12 +93,6 @@ const FloatingEventIcon = ({
 	const scale = useSharedValue(0.6)
 	const floatY = useSharedValue(0)
 	const rotation = useSharedValue(Math.random() * 0.05 - 0.025)
-
-	const triggerSuperLightHaptic = () => {
-		if (Platform.OS === 'ios') {
-			void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
-		}
-	}
 
 	useAnimatedReaction(
 		() => tapCount.value,
@@ -221,12 +225,8 @@ export const CalendarAnimation = ({
 	const calendarTapScale = useSharedValue(1)
 	const tapCount = useSharedValue(0)
 
-	const triggerHaptic = () => {
-		void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
-	}
-
 	const tapGesture = Gesture.Tap().onBegin(() => {
-		runOnJS(triggerHaptic)()
+		runOnJS(triggerCalendarAnimationHaptic)()
 
 		calendarTapScale.value = withSequence(
 			withTiming(0.95, { duration: 100, easing: Easing.out(Easing.quad) }),

--- a/src/components/Settings/settings-screen.tsx
+++ b/src/components/Settings/settings-screen.tsx
@@ -35,6 +35,12 @@ import SettingsLogo from './settings-logo'
 import SettingsMenu from './settings-menu'
 import StudentInfoSection from './student-info-section'
 
+function trackHetznerClick(): void {
+	trackEvent('Sponsor', {
+		sponsor: 'Hetzner'
+	})
+}
+
 export default function Settings(): React.JSX.Element {
 	const { userKind = USER_GUEST } = use<UserKindContextType>(UserKindContext)
 	const { resetOrder } = use(DashboardContext)
@@ -69,12 +75,6 @@ export default function Settings(): React.JSX.Element {
 				}
 			]
 		)
-	}
-
-	const trackHetznerClick = (): void => {
-		trackEvent('Sponsor', {
-			sponsor: 'Hetzner'
-		})
 	}
 
 	const { data, isLoading, isSuccess, refetch, isError } = useQuery({

--- a/src/components/Timetable/timetable-animation.tsx
+++ b/src/components/Timetable/timetable-animation.tsx
@@ -21,6 +21,10 @@ import PlatformIcon from '@/components/Universal/icon'
 import type { MaterialIcon } from '@/types/material-icons'
 import { toColor } from '@/utils/uniwind-utils'
 
+function triggerTimetableAnimationHaptic(): void {
+	void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
+}
+
 interface TimetableAnimationProps {
 	size?: number
 }
@@ -205,12 +209,8 @@ export const TimetableAnimation = ({
 	const calendarTapScale = useSharedValue(1)
 	const tapCount = useSharedValue(0)
 
-	const triggerHaptic = () => {
-		void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
-	}
-
 	const tapGesture = Gesture.Tap().onBegin(() => {
-		runOnJS(triggerHaptic)()
+		runOnJS(triggerTimetableAnimationHaptic)()
 
 		calendarTapScale.value = withSequence(
 			withTiming(0.95, { duration: 100, easing: Easing.out(Easing.quad) }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Hoists 9 pure handler functions from component bodies to module scope, clearing all React Doctor `prefer-module-scope-pure-function` warnings.

### Handlers moved

| File | Function |
|---|---|
| `about.tsx` | `handleWebsitePress`, `handleContributorsPress` |
| `sports-card.tsx` | `handleSportsItemPress` |
| `error-view.tsx` | `handleErrorButtonPress` |
| `event-error-view.tsx` | `getEventTypeIcon` |
| `calendar-animation.tsx` | `triggerSuperLightHaptic`, `triggerCalendarAnimationHaptic` |
| `timetable-animation.tsx` | `triggerTimetableAnimationHaptic` |
| `settings-screen.tsx` | `trackHetznerClick` |

Handlers that still need closure over props (`title`, `onButtonPress`) accept them as parameters instead of being inlined in the component.

No behavior changes.

## Verification

- `bun tsc --noEmit`
- `bun lint`
- `bun test` — 237 pass
- React Doctor: **0** `prefer-module-scope-pure-function` warnings (was 9)

## Checklist

- [ ] I've tested my changes on iOS
- [ ] I've tested my changes on Android
- [ ] I've tested my changes on Web
- [ ] I've added or updated documentation (if needed)
- [x] I've reviewed the related issues, if any
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2b4b-d616-7de6-8abf-a1a037763376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2b4b-d616-7de6-8abf-a1a037763376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

