### PR TITLE
refactor: migrate lightTheme margins to uniwind spacing tokens

### DIFF
--- a/src/components/Food/items-picker-screen.tsx
+++ b/src/components/Food/items-picker-screen.tsx
@@ -1,4 +1,3 @@
-import { FlashList } from '@shopify/flash-list'
 import { selectionAsync } from 'expo-haptics'
 import { useNavigation } from 'expo-router'
 import type React from 'react'
@@ -8,11 +7,11 @@ import { Platform, Pressable, Text, View } from 'react-native'
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context'
 import { useCSSVariable, useUniwind } from 'uniwind'
 import PlatformIcon from '@/components/Universal/icon'
+import { FlashList } from '@/components/Universal/styled'
 import allergenMap from '@/data/allergens.json'
 import flapMap from '@/data/mensa-flags.json'
 import { useFoodFilterStore } from '@/hooks/useFoodFilterStore'
 import type { LanguageKey } from '@/localization/i18n'
-import { lightTheme } from '@/styles/themes'
 import { toColor } from '@/utils/uniwind-utils'
 
 interface PickerItem {
@@ -141,11 +140,7 @@ const ItemsPickerScreen = ({
 				data={filteredEntries}
 				renderItem={renderItem}
 				estimatedItemSize={60}
-				contentContainerStyle={{
-					paddingHorizontal: lightTheme.margins.page,
-					paddingTop: 10,
-					paddingBottom: lightTheme.margins.bottomSafeArea
-				}}
+				contentContainerClassName="px-page pt-2.5 pb-bottom-safe"
 				showsVerticalScrollIndicator={false}
 				scrollEventThrottle={16}
 				disableAutoLayout

--- a/src/components/Food/meal-day.tsx
+++ b/src/components/Food/meal-day.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Pressable, StyleSheet, Text, View } from 'react-native'
+import { Pressable, Text, View } from 'react-native'
 import Collapsible from 'react-native-collapsible'
 import { useCSSVariable } from 'uniwind'
 import PlatformIcon from '@/components/Universal/icon'
@@ -62,7 +62,7 @@ const MealCategory = ({
 	}
 
 	return (
-		<View style={styles.categoryContainerCollapsed}>
+		<View className="pb-2">
 			<Pressable
 				onPress={() => {
 					toggleCollapsed()
@@ -70,7 +70,7 @@ const MealCategory = ({
 				style={({ pressed }) => [{ opacity: pressed ? 0.8 : 1 }]}
 				hitSlop={{ top: 6, bottom: 6 }}
 			>
-				<View style={styles.categoryContainer}>
+				<View className="flex-row items-center justify-between py-[3px]">
 					<Text className="text-label text-[15px] font-medium">
 						{t(`categories.${category}`, category)}
 					</Text>
@@ -172,7 +172,7 @@ export const MealDay = ({ day }: { day: Food }): React.JSX.Element => {
 	}
 
 	return (
-		<View style={styles.foodContainer}>
+		<View>
 			<RestaurantSection
 				title="Mensa Ingolstadt"
 				meals={mealData.ingolstadtMensa}
@@ -196,19 +196,3 @@ export const MealDay = ({ day }: { day: Food }): React.JSX.Element => {
 		</View>
 	)
 }
-
-const styles = StyleSheet.create({
-	categoryContainer: {
-		alignItems: 'center',
-		flexDirection: 'row',
-		justifyContent: 'space-between',
-		paddingBottom: 3,
-		paddingTop: 3
-	},
-	categoryContainerCollapsed: {
-		paddingBottom: 8
-	},
-	foodContainer: {
-		paddingBottom: 90
-	}
-})

--- a/src/components/Timetable/timetable-list.tsx
+++ b/src/components/Timetable/timetable-list.tsx
@@ -1,7 +1,6 @@
-import {
-	FlashList,
-	type ListRenderItemInfo,
-	type FlashList as ShopifyFlashList
+import type {
+	ListRenderItemInfo,
+	FlashList as ShopifyFlashList
 } from '@shopify/flash-list'
 import Color from 'color'
 import { useFocusEffect, useNavigation, useRouter } from 'expo-router'
@@ -21,11 +20,11 @@ import DragDropView from '@/components/Exclusive/drag-view'
 import Badge from '@/components/Universal/badge'
 import ColorBand from '@/components/Universal/color-band'
 import LoadingIndicator from '@/components/Universal/loading-indicator'
+import { FlashList } from '@/components/Universal/styled'
 import TimeDisplay from '@/components/Universal/time-display'
 import useRouteParamsStore from '@/hooks/useRouteParamsStore'
 import { useTimetableStore } from '@/hooks/useTimetableStore'
 import i18n from '@/localization/i18n'
-import { lightTheme } from '@/styles/themes'
 import type { ITimetableViewProps } from '@/types/timetable'
 import type {
 	ExamEntry,
@@ -527,7 +526,7 @@ export default function TimetableList({
 					data={flatData}
 					extraData={listThemeData}
 					renderItem={renderItem}
-					contentContainerStyle={listStyles.contentContainer}
+					contentContainerClassName="px-page pb-bottom-safe"
 					estimatedItemSize={100}
 					keyExtractor={(item: FlatListItem, index: number) => {
 						// Updated keyExtractor for FlatListItem
@@ -571,10 +570,6 @@ export default function TimetableList({
 const listStyles = StyleSheet.create({
 	list: {
 		flex: 1
-	},
-	contentContainer: {
-		paddingBottom: 80,
-		paddingHorizontal: lightTheme.margins.page
 	}
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Finishes migrating the last runtime `lightTheme.margins` usages to Uniwind spacing tokens (`px-page`, `pb-bottom-safe`).

## Changes

- **`items-picker-screen.tsx`** — styled `FlashList` + `contentContainerClassName="px-page pt-2.5 pb-bottom-safe"`; drops `lightTheme` import
- **`timetable-list.tsx`** — same token migration; fixes bottom inset from **80px → 90px** to match `--spacing-bottom-safe`
- **`meal-day.tsx`** — removes duplicate `paddingBottom: 90` (parent scroll already provides bottom safe area); migrates category row padding to `className`

## Test plan

- [x] `bun lint`
- [x] `bun tsc --noEmit`
- [ ] Food allergens/flags picker list padding
- [ ] Timetable list horizontal inset and bottom scroll space
- [ ] Food meal day scroll (no double bottom gap)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2dcc-c451-7068-9a52-47b223f7fd54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2dcc-c451-7068-9a52-47b223f7fd54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

