### PR TITLE
fix: resolve hook violations in onboarding and whatsnew screens

### DIFF
--- a/src/app/(screens)/onboarding.tsx
+++ b/src/app/(screens)/onboarding.tsx
@@ -1,10 +1,10 @@
-/** biome-ignore-all lint/correctness/useHookAtTopLevel: not a problem here */
 import * as Haptics from 'expo-haptics'
 import { router } from 'expo-router'
 import type React from 'react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
+	type ColorValue,
 	Dimensions,
 	Linking,
 	Platform,
@@ -17,24 +17,129 @@ import DeviceInfo from 'react-native-device-info'
 import Animated, {
 	Easing,
 	runOnJS,
+	type SharedValue,
 	useAnimatedStyle,
 	useSharedValue,
 	withDelay,
-	withSequence,
 	withTiming
 } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useCSSVariable } from 'uniwind'
+import { OnboardingCard } from '@/components/Flow/onboarding-card'
 import AnimatedText from '@/components/Flow/svgs/animated-text'
 import LogoSVG from '@/components/Flow/svgs/logo'
 import LogoTextSVG from '@/components/Flow/svgs/logo-text'
-import WhatsNewBox from '@/components/Flow/whats-new-box'
 import PlatformIcon from '@/components/Universal/icon'
 import { PRIVACY_URL } from '@/data/constants'
 import { useFlowStore } from '@/hooks/useFlowStore'
 import type { OnboardingCardData } from '@/types/data'
 import { getContrastColor } from '@/utils/ui-utils'
 import { toColor } from '@/utils/uniwind-utils'
+
+const ONBOARDING_CARD_COUNT = 3
+
+interface OnboardingContinueButtonProps {
+	buttonTextColor: string
+	disabled: boolean
+	label: string
+	onContinue: () => void
+}
+
+function OnboardingContinueButton({
+	buttonTextColor,
+	disabled,
+	label,
+	onContinue
+}: OnboardingContinueButtonProps): React.JSX.Element {
+	return (
+		<Pressable
+			className="self-center bg-primary rounded-md px-6 py-3.5 w-1/2"
+			onPress={onContinue}
+			disabled={disabled}
+		>
+			<Text
+				className="text-base font-bold text-center"
+				style={{ color: buttonTextColor }}
+			>
+				{label}
+			</Text>
+		</Pressable>
+	)
+}
+
+interface OnboardingLegalAreaProps {
+	buttonDisabled: boolean
+	buttonTextColor: string
+	continueLabel: string
+	labelColor: ColorValue | undefined
+	legalOpacity: SharedValue<number>
+	legalTranslateY: SharedValue<number>
+	onContinue: () => void
+	privacyLabel: string
+	agreePrefix: string
+	agreeSuffix: string
+	textColor: ColorValue | undefined
+	windowHeight: number
+	windowWidth: number
+}
+
+function OnboardingLegalArea({
+	buttonDisabled,
+	buttonTextColor,
+	continueLabel,
+	labelColor,
+	legalOpacity,
+	legalTranslateY,
+	onContinue,
+	privacyLabel,
+	agreePrefix,
+	agreeSuffix,
+	textColor,
+	windowHeight,
+	windowWidth
+}: OnboardingLegalAreaProps): React.JSX.Element {
+	const legalAnimatedStyle = useAnimatedStyle(() => ({
+		opacity: legalOpacity.value,
+		transform: [{ translateY: legalTranslateY.value }]
+	}))
+
+	return (
+		<Animated.View style={legalAnimatedStyle}>
+			<View
+				className="items-center flex-row justify-center"
+				style={{
+					marginBottom: windowHeight * 0.035,
+					marginTop: windowHeight * 0.008
+				}}
+			>
+				<Text
+					className="flex-wrap flex-1 shrink text-center text-sm"
+					style={{ color: labelColor, maxWidth: windowWidth }}
+					numberOfLines={2}
+				>
+					<Text>{agreePrefix}</Text>
+					<Text
+						disabled={buttonDisabled}
+						className="font-bold"
+						style={{ color: textColor }}
+						onPress={() => {
+							void Linking.openURL(PRIVACY_URL)
+						}}
+					>
+						{privacyLabel}
+					</Text>
+					<Text>{agreeSuffix}</Text>
+				</Text>
+			</View>
+			<OnboardingContinueButton
+				buttonTextColor={buttonTextColor}
+				disabled={buttonDisabled}
+				label={continueLabel}
+				onContinue={onContinue}
+			/>
+		</Animated.View>
+	)
+}
 
 export default function OnboardingScreen(): React.JSX.Element {
 	const { t } = useTranslation('flow')
@@ -46,6 +151,30 @@ export default function OnboardingScreen(): React.JSX.Element {
 	const labelSecondaryColor = toColor(useCSSVariable('--color-label-secondary'))
 	const primaryColor = String(useCSSVariable('--color-primary') ?? '#007aff')
 	const buttonTextColor = getContrastColor(primaryColor)
+	const insets = useSafeAreaInsets()
+	const reanimatedWindow = useWindowDimensions()
+	const window = Dimensions.get('window')
+	const [isWhobbleDisabled, setWhobbleDisabled] = useState(true)
+	const [buttonDisabled, setButtonDisabled] = useState(true)
+
+	const cardOpacity0 = useSharedValue(0)
+	const cardOpacity1 = useSharedValue(0)
+	const cardOpacity2 = useSharedValue(0)
+	const cardTranslateY0 = useSharedValue(20)
+	const cardTranslateY1 = useSharedValue(20)
+	const cardTranslateY2 = useSharedValue(20)
+	const cardOpacities = [cardOpacity0, cardOpacity1, cardOpacity2]
+	const cardTranslateYs = [cardTranslateY0, cardTranslateY1, cardTranslateY2]
+
+	const legalOpacity = useSharedValue(0)
+	const legalTranslateY = useSharedValue(20)
+	const logoOpacity = useSharedValue(0)
+	const textTranslateY = useSharedValue(20)
+	const textOpacity = useSharedValue(0)
+	const cardsViewHeight = useSharedValue(0)
+	const textLogoOpacity = useSharedValue(1)
+	const logoMargin = useSharedValue(1)
+	const helpOpacity = useSharedValue(0)
 
 	const data: OnboardingCardData[] = [
 		{
@@ -57,7 +186,6 @@ export default function OnboardingScreen(): React.JSX.Element {
 				web: 'Layers'
 			}
 		},
-
 		{
 			title: t('onboarding.cards.title2'),
 			description: t('onboarding.cards.description2'),
@@ -78,182 +206,49 @@ export default function OnboardingScreen(): React.JSX.Element {
 		}
 	]
 
-	const ContinueButton = (): React.JSX.Element => {
-		return (
-			<Pressable
-				className="self-center bg-primary rounded-md px-6 py-3.5 w-1/2"
-				onPress={() => {
-					if (Platform.OS === 'ios') {
-						void Haptics.selectionAsync()
-					}
-					setOnboarded()
-					toggleUpdated()
-					setAnalyticsAllowed(true)
-					router.navigate({
-						pathname: '/login',
-						params: { fromOnboarding: 'true' }
-					})
-				}}
-				disabled={buttonDisabled}
-			>
-				<Text
-					className="text-base font-bold text-center"
-					style={{ color: buttonTextColor }}
-				>
-					{t('whatsnew.continue')}
-				</Text>
-			</Pressable>
-		)
+	const textLogoAnimatedStyle = useAnimatedStyle(() => ({
+		opacity: textLogoOpacity.value
+	}))
+
+	const logoAnimatedStyle = useAnimatedStyle(() => ({
+		opacity: logoOpacity.value
+	}))
+
+	const textAnimatedStyle = useAnimatedStyle(() => ({
+		transform: [{ translateY: textTranslateY.value }],
+		opacity: textOpacity.value
+	}))
+
+	const helpAnimatedStyle = useAnimatedStyle(() => ({
+		position: 'absolute',
+		top: insets.top + 15,
+		right: 18,
+		opacity: helpOpacity.value
+	}))
+
+	const logoFadeOutAnimatedStyle = useAnimatedStyle(() => ({
+		opacity: logoOpacity.value,
+		height: 150 * logoMargin.value,
+		marginTop: logoMargin.value * reanimatedWindow.height * 0.5,
+		marginBottom: logoMargin.value * 40
+	}))
+
+	const cardsViewAnimatedStyle = useAnimatedStyle(() => ({
+		minHeight: cardsViewHeight.value
+	}))
+
+	const handleContinue = (): void => {
+		if (Platform.OS === 'ios') {
+			void Haptics.selectionAsync()
+		}
+		setOnboarded()
+		toggleUpdated()
+		setAnalyticsAllowed(true)
+		router.navigate({
+			pathname: '/login',
+			params: { fromOnboarding: 'true' }
+		})
 	}
-
-	const cardsOpacity = data.map(() => useSharedValue(0))
-	const cardsTranslateY = data.map(() => useSharedValue(20))
-	const legalOpacity = useSharedValue(0)
-	const legalTranslateY = useSharedValue(20)
-	const logoOpacity = useSharedValue(0)
-	const textTranslateY = useSharedValue(20)
-	const textOpacity = useSharedValue(0)
-	const cardsViewHeight = useSharedValue(0)
-	const textLogoOpacity = useSharedValue(1)
-	const logoMargin = useSharedValue(1)
-	const helpOpacity = useSharedValue(0)
-	const [isWhobbleDisabled, setWhobbleDisabled] = useState(true)
-	const window = Dimensions.get('window')
-
-	const CardsElement = (): React.JSX.Element => {
-		return (
-			<Animated.View className="justify-center pt-5 gap-3 mx-10">
-				{data.map(({ title, description, icon }, index) => {
-					const rotation = useSharedValue(0)
-
-					const animatedStyles = useAnimatedStyle(() => {
-						return {
-							transform: [{ rotateZ: `${rotation.value}deg` }]
-						}
-					})
-
-					const handlePress = (): void => {
-						if (Platform.OS === 'ios') {
-							void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
-						}
-						const direction = Math.random() > 0.5 ? 1 : -1
-						rotation.value = withSequence(
-							withTiming(direction * -1.5, {
-								duration: 100,
-								easing: Easing.linear
-							}),
-							withTiming(direction * 1, {
-								duration: 100,
-								easing: Easing.linear
-							}),
-							withTiming(direction * -0.5, {
-								duration: 100,
-								easing: Easing.linear
-							}),
-							withTiming(0, {
-								duration: 100,
-								easing: Easing.linear
-							})
-						)
-					}
-
-					const animatedStyle = useAnimatedStyle(() => ({
-						opacity: cardsOpacity[index].value,
-						transform: [{ translateY: cardsTranslateY[index].value }]
-					}))
-
-					return (
-						<Pressable
-							onPress={() => {
-								if (!isWhobbleDisabled) {
-									handlePress()
-								}
-							}}
-							key={title}
-						>
-							<Animated.View style={animatedStyles}>
-								<Animated.View style={animatedStyle}>
-									<WhatsNewBox
-										title={title}
-										description={description}
-										icon={icon}
-									/>
-								</Animated.View>
-							</Animated.View>
-						</Pressable>
-					)
-				})}
-			</Animated.View>
-		)
-	}
-
-	const LegalArea = (): React.JSX.Element => {
-		const legalAnimatedStyle = useAnimatedStyle(() => ({
-			opacity: legalOpacity.value,
-			transform: [{ translateY: legalTranslateY.value }]
-		}))
-		return (
-			<Animated.View style={legalAnimatedStyle}>
-				<View
-					className="items-center flex-row justify-center"
-					style={{
-						marginBottom: window.height * 0.035,
-						marginTop: window.height * 0.008
-					}}
-				>
-					<Text
-						className="flex-wrap flex-1 shrink text-center text-sm"
-						style={{ color: labelColor, maxWidth: window.width }}
-						numberOfLines={2}
-					>
-						<Text>{t('onboarding.links.agree1')}</Text>
-						<Text
-							disabled={buttonDisabled}
-							className="font-bold"
-							style={{ color: textColor }}
-							onPress={() => {
-								void Linking.openURL(PRIVACY_URL)
-							}}
-						>
-							{t('onboarding.links.privacy')}
-						</Text>
-						<Text>{t('onboarding.links.agree2')}</Text>
-					</Text>
-				</View>
-				<ContinueButton />
-			</Animated.View>
-		)
-	}
-
-	const insets = useSafeAreaInsets()
-
-	const textLogoAnimatedStyle = useAnimatedStyle(() => {
-		return {
-			opacity: textLogoOpacity.value
-		}
-	})
-
-	const logoAnimatedStyle = useAnimatedStyle(() => {
-		return {
-			opacity: logoOpacity.value
-		}
-	})
-
-	const textAnimatedStyle = useAnimatedStyle(() => {
-		return {
-			transform: [{ translateY: textTranslateY.value }],
-			opacity: textOpacity.value
-		}
-	})
-
-	const helpAnimatedStyle = useAnimatedStyle(() => {
-		return {
-			position: 'absolute',
-			top: insets.top + 15,
-			right: 18,
-			opacity: helpOpacity.value
-		}
-	})
 
 	useEffect(() => {
 		logoOpacity.value = withDelay(
@@ -302,23 +297,23 @@ export default function OnboardingScreen(): React.JSX.Element {
 										}
 									)
 									const initialDelay = 800
-									data.forEach((_, index) => {
+									for (let index = 0; index < ONBOARDING_CARD_COUNT; index++) {
 										const delay = initialDelay + index * 100
 
-										cardsOpacity[index].value = withDelay(
+										cardOpacities[index].value = withDelay(
 											delay,
 											withTiming(1, {
 												duration: 500
 											})
 										)
 
-										cardsTranslateY[index].value = withDelay(
+										cardTranslateYs[index].value = withDelay(
 											delay,
 											withTiming(0, {
 												duration: 500
 											})
 										)
-									})
+									}
 									runOnJS(setWhobbleDisabled)(false)
 									helpOpacity.value = withDelay(
 										1400,
@@ -359,23 +354,6 @@ export default function OnboardingScreen(): React.JSX.Element {
 		)
 	}, [])
 
-	const reanimatedWindow = useWindowDimensions()
-	const logoFadeOutAnimatedStyle = useAnimatedStyle(() => {
-		return {
-			opacity: logoOpacity.value,
-			height: 150 * logoMargin.value,
-			marginTop: logoMargin.value * reanimatedWindow.height * 0.5,
-			marginBottom: logoMargin.value * 40
-		}
-	})
-
-	const cardsViewAnimatedStyle = useAnimatedStyle(() => {
-		return {
-			minHeight: cardsViewHeight.value
-		}
-	})
-
-	const [buttonDisabled, setButtonDisabled] = useState(true)
 	const scaleFontSize = (size: number): number => {
 		if (DeviceInfo.isTablet() || Platform.OS === 'web') {
 			return size
@@ -384,6 +362,7 @@ export default function OnboardingScreen(): React.JSX.Element {
 		return size * (window.width / guidelineBaseWidth)
 	}
 	const scaledHeading = scaleFontSize(33)
+
 	return (
 		<>
 			<View
@@ -433,11 +412,37 @@ export default function OnboardingScreen(): React.JSX.Element {
 					/>
 				</View>
 				<Animated.View className="grow-[0.5]" style={cardsViewAnimatedStyle}>
-					<CardsElement />
+					<View className="justify-center pt-5 gap-3 mx-10">
+						{data.map(({ title, description, icon }, index) => (
+							<OnboardingCard
+								key={title}
+								title={title}
+								description={description}
+								icon={icon}
+								opacity={cardOpacities[index]}
+								translateY={cardTranslateYs[index]}
+								wobbleDisabled={isWhobbleDisabled}
+							/>
+						))}
+					</View>
 				</Animated.View>
 
 				<View className="flex-1 justify-center w-[95%]">
-					<LegalArea />
+					<OnboardingLegalArea
+						buttonDisabled={buttonDisabled}
+						buttonTextColor={buttonTextColor}
+						continueLabel={t('whatsnew.continue')}
+						labelColor={labelColor}
+						legalOpacity={legalOpacity}
+						legalTranslateY={legalTranslateY}
+						onContinue={handleContinue}
+						privacyLabel={t('onboarding.links.privacy')}
+						agreePrefix={t('onboarding.links.agree1')}
+						agreeSuffix={t('onboarding.links.agree2')}
+						textColor={textColor}
+						windowHeight={window.height}
+						windowWidth={window.width}
+					/>
 				</View>
 				<Animated.View
 					className="items-center bottom-[30px] absolute w-full"

--- a/src/app/(screens)/whatsnew.tsx
+++ b/src/app/(screens)/whatsnew.tsx
@@ -1,92 +1,48 @@
-/** biome-ignore-all lint/correctness/useHookAtTopLevel: not a problem here */
 import * as Application from 'expo-application'
-import { ImpactFeedbackStyle, impactAsync } from 'expo-haptics'
-import { router } from 'expo-router'
+import { Redirect, router } from 'expo-router'
 import type React from 'react'
-import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform, Pressable, Text, View } from 'react-native'
-import Animated, {
-	Easing,
-	useAnimatedStyle,
-	useSharedValue,
-	withDelay,
-	withSequence,
-	withTiming
-} from 'react-native-reanimated'
+import { Pressable, Text, View } from 'react-native'
 import { useCSSVariable } from 'uniwind'
-import WhatsNewBox from '@/components/Flow/whats-new-box'
+import { WhatsNewItem } from '@/components/Flow/whats-new-item'
 import changelogData from '@/data/changelog.json'
 import { useFlowStore } from '@/hooks/useFlowStore'
 import type { LanguageKey } from '@/localization/i18n'
-import type { Changelog } from '@/types/data'
+import type { Changelog, Version } from '@/types/data'
 import { convertToMajorMinorPatch } from '@/utils/app-utils'
 import { getContrastColor } from '@/utils/ui-utils'
 import { toColor } from '@/utils/uniwind-utils'
 
 export default function WhatsNewScreen(): React.JSX.Element {
-	const changelog: Changelog = changelogData as Changelog
+	const version = convertToMajorMinorPatch(
+		Application.nativeApplicationVersion ?? '0.0.0'
+	)
+	const changelog = changelogData as Changelog
+	const items = changelog.version[version]
+
+	if (items === undefined) {
+		return <Redirect href="/(tabs)" />
+	}
+
+	return <WhatsNewContent version={version} items={items} />
+}
+
+interface WhatsNewContentProps {
+	version: string
+	items: Version[]
+}
+
+function WhatsNewContent({
+	version,
+	items
+}: WhatsNewContentProps): React.JSX.Element {
 	const { t, i18n } = useTranslation('flow')
 	const primaryColor = String(
 		toColor(useCSSVariable('--color-primary')) ?? '#007aff'
 	)
 	const buttonTextColor = getContrastColor(primaryColor)
-	const version = convertToMajorMinorPatch(
-		Application.nativeApplicationVersion ?? '0.0.0'
-	)
 	const toggleUpdated = useFlowStore((state) => state.toggleUpdated)
-	if (changelog.version[version] === undefined) {
-		router.navigate('/(tabs)')
-	}
-	const totalItems = Object.keys(changelog.version[version] ?? []).flatMap(
-		(key) => changelog.version[key]
-	).length
-
-	const opacityValues = changelog.version[version].map(() => useSharedValue(0))
-	const rotationValues = Array.from({ length: totalItems }, () =>
-		useSharedValue(0)
-	)
-
-	const handlePress = (index: number): void => {
-		if (Platform.OS === 'ios') {
-			void impactAsync(ImpactFeedbackStyle.Light)
-		}
-		const direction = Math.random() > 0.5 ? 1 : -1
-		const rotation = rotationValues[index]
-		rotation.value = withSequence(
-			withTiming(direction * -1.5, {
-				duration: 100,
-				easing: Easing.linear
-			}),
-			withTiming(direction * 1, {
-				duration: 100,
-				easing: Easing.linear
-			}),
-			withTiming(direction * -0.5, {
-				duration: 100,
-				easing: Easing.linear
-			}),
-			withTiming(0, {
-				duration: 100,
-				easing: Easing.linear
-			})
-		)
-	}
-
-	useEffect(() => {
-		const delay = 200
-		setTimeout(() => {
-			opacityValues.forEach((opacity, index) => {
-				opacity.value = withDelay(
-					index * 400,
-					withTiming(1, {
-						duration: 800,
-						easing: Easing.linear
-					})
-				)
-			})
-		}, delay)
-	}, [])
+	const language = i18n.language as LanguageKey
 
 	return (
 		<View className="bg-contrast flex-1 gap-5 px-5 py-10">
@@ -102,44 +58,15 @@ export default function WhatsNewScreen(): React.JSX.Element {
 			</View>
 
 			<View className="flex-[4] justify-center gap-3">
-				{changelog.version[version]?.map(
-					({ title, description, icon }, index) => {
-						const opacityStyle = useAnimatedStyle(() => {
-							return {
-								opacity: opacityValues[index].value
-							}
-						})
-
-						const rotationStyle = useAnimatedStyle(() => {
-							return {
-								transform: [
-									{
-										rotateZ: `${rotationValues[index].value}deg`
-									}
-								]
-							}
-						})
-
-						return (
-							<Animated.View
-								key={title[i18n.language as LanguageKey]}
-								style={[opacityStyle, rotationStyle]}
-							>
-								<Pressable
-									onPress={() => {
-										handlePress(index)
-									}}
-								>
-									<WhatsNewBox
-										title={title[i18n.language as LanguageKey]}
-										description={description[i18n.language as LanguageKey]}
-										icon={icon}
-									/>
-								</Pressable>
-							</Animated.View>
-						)
-					}
-				)}
+				{items.map(({ title, description, icon }, index) => (
+					<WhatsNewItem
+						key={title[language]}
+						title={title[language]}
+						description={description[language]}
+						icon={icon}
+						index={index}
+					/>
+				))}
 			</View>
 			<View className="flex-1">
 				<Pressable

--- a/src/components/Flow/onboarding-card.tsx
+++ b/src/components/Flow/onboarding-card.tsx
@@ -1,0 +1,80 @@
+import * as Haptics from 'expo-haptics'
+import type React from 'react'
+import { Platform, Pressable } from 'react-native'
+import Animated, {
+	Easing,
+	type SharedValue,
+	useAnimatedStyle,
+	useSharedValue,
+	withSequence,
+	withTiming
+} from 'react-native-reanimated'
+import type { OnboardingCardData } from '@/types/data'
+import WhatsNewBox from './whats-new-box'
+
+interface OnboardingCardProps {
+	title: string
+	description: string
+	icon: OnboardingCardData['icon']
+	opacity: SharedValue<number>
+	translateY: SharedValue<number>
+	wobbleDisabled: boolean
+}
+
+export function OnboardingCard({
+	title,
+	description,
+	icon,
+	opacity,
+	translateY,
+	wobbleDisabled
+}: OnboardingCardProps): React.JSX.Element {
+	const rotation = useSharedValue(0)
+
+	const wobbleStyle = useAnimatedStyle(() => ({
+		transform: [{ rotateZ: `${rotation.value}deg` }]
+	}))
+
+	const entranceStyle = useAnimatedStyle(() => ({
+		opacity: opacity.value,
+		transform: [{ translateY: translateY.value }]
+	}))
+
+	const handlePress = (): void => {
+		if (wobbleDisabled) {
+			return
+		}
+		if (Platform.OS === 'ios') {
+			void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
+		}
+		const direction = Math.random() > 0.5 ? 1 : -1
+		rotation.value = withSequence(
+			withTiming(direction * -1.5, {
+				duration: 100,
+				easing: Easing.linear
+			}),
+			withTiming(direction * 1, {
+				duration: 100,
+				easing: Easing.linear
+			}),
+			withTiming(direction * -0.5, {
+				duration: 100,
+				easing: Easing.linear
+			}),
+			withTiming(0, {
+				duration: 100,
+				easing: Easing.linear
+			})
+		)
+	}
+
+	return (
+		<Pressable onPress={handlePress}>
+			<Animated.View style={wobbleStyle}>
+				<Animated.View style={entranceStyle}>
+					<WhatsNewBox title={title} description={description} icon={icon} />
+				</Animated.View>
+			</Animated.View>
+		</Pressable>
+	)
+}

--- a/src/components/Flow/whats-new-item.tsx
+++ b/src/components/Flow/whats-new-item.tsx
@@ -1,0 +1,87 @@
+import { ImpactFeedbackStyle, impactAsync } from 'expo-haptics'
+import type React from 'react'
+import { useEffect } from 'react'
+import { Platform, Pressable } from 'react-native'
+import Animated, {
+	Easing,
+	useAnimatedStyle,
+	useSharedValue,
+	withSequence,
+	withTiming
+} from 'react-native-reanimated'
+import type { Version } from '@/types/data'
+import WhatsNewBox from './whats-new-box'
+
+interface WhatsNewItemProps {
+	title: string
+	description: string
+	icon: Version['icon']
+	index: number
+}
+
+export function WhatsNewItem({
+	title,
+	description,
+	icon,
+	index
+}: WhatsNewItemProps): React.JSX.Element {
+	const opacity = useSharedValue(0)
+	const rotation = useSharedValue(0)
+
+	useEffect(() => {
+		const timeout = setTimeout(
+			() => {
+				opacity.value = withTiming(1, {
+					duration: 800,
+					easing: Easing.linear
+				})
+			},
+			200 + index * 400
+		)
+
+		return () => {
+			clearTimeout(timeout)
+		}
+	}, [index, opacity])
+
+	const opacityStyle = useAnimatedStyle(() => ({
+		opacity: opacity.value
+	}))
+
+	const rotationStyle = useAnimatedStyle(() => ({
+		transform: [{ rotateZ: `${rotation.value}deg` }]
+	}))
+
+	const handlePress = (): void => {
+		if (Platform.OS === 'ios') {
+			void impactAsync(ImpactFeedbackStyle.Light)
+		}
+		const direction = Math.random() > 0.5 ? 1 : -1
+		rotation.value = withSequence(
+			withTiming(direction * -1.5, {
+				duration: 100,
+				easing: Easing.linear
+			}),
+			withTiming(direction * 1, {
+				duration: 100,
+				easing: Easing.linear
+			}),
+			withTiming(direction * -0.5, {
+				duration: 100,
+				easing: Easing.linear
+			}),
+			withTiming(0, {
+				duration: 100,
+				easing: Easing.linear
+			})
+		)
+	}
+
+	return (
+		<Animated.View style={[opacityStyle, rotationStyle]}>
+			<Pressable onPress={handlePress}>
+				<WhatsNewBox title={title} description={description} icon={icon} />
+			</Pressable>
+		</Animated.View>
+	)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes intermittent `undefined is not a function` crashes on app launch for users routed through onboarding or what's new.

**What's new**
- Guard missing changelog versions with `<Redirect href="/(tabs)" />` before any dependent hooks run (replaces `router.navigate` + continued execution that called `.map` on `undefined`).
- Extract `WhatsNewItem` so each card owns its `useSharedValue` / `useAnimatedStyle` hooks at the component top level.

**Onboarding**
- Extract `OnboardingCard`, `OnboardingContinueButton`, and `OnboardingLegalArea` to module scope.
- Replace `data.map(() => useSharedValue(...))` with three explicit shared values passed into card components.
- Fix hook ordering (`useState`, dimensions, shared values, animated styles, then `useEffect`).

These patterns were flagged by React Doctor as incompatible with React Compiler (`reactCompiler: true`).

## Checklist

- [ ] Tested on iOS
- [ ] Tested on Android
- [ ] Tested on Web
- [x] `bun tsc --noEmit` passes
- [x] `bun lint` passes

## Additional notes

No user-facing copy or navigation flow changes beyond the crash fix on missing changelog entries.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3302-db91-7d73-b060-5f3270518c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3302-db91-7d73-b060-5f3270518c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

