### PR TITLE
fix: downgrade wallet-manager for legacy architecture compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -83,7 +83,7 @@
         "react-native-select-dropdown": "^4.0.1",
         "react-native-svg": "15.12.1",
         "react-native-view-shot": "~4.0.3",
-        "react-native-wallet-manager": "^2.1.0",
+        "react-native-wallet-manager": "1.1.3",
         "react-native-web": "^0.21.2",
         "react-native-webview": "13.15.0",
         "react-qr-code": "^2.0.18",
@@ -2054,7 +2054,7 @@
 
     "react-native-view-shot": ["react-native-view-shot@4.0.3", "", { "dependencies": { "html2canvas": "^1.4.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ=="],
 
-    "react-native-wallet-manager": ["react-native-wallet-manager@2.1.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-IpJFr9ZG9XMU4Feo2zZR3YYFQM4jXRqT3yN5rWM/LilNvRKsTiQDnz7aQy5JWZyUVOo1V40yo/UINk+RBhxmAA=="],
+    "react-native-wallet-manager": ["react-native-wallet-manager@1.1.3", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-qF7KPiUaZdZQlHbOQsqJUQZgv7v47K3KkhlPERt9WSXc6/VY8BAbcOrlx5vcNjU/gZAy57l5aw5ZPCp5deyKAg=="],
 
     "react-native-web": ["react-native-web@0.21.2", "", { "dependencies": { "@babel/runtime": "^7.18.6", "@react-native/normalize-colors": "^0.74.1", "fbjs": "^3.0.4", "inline-style-prefixer": "^7.0.1", "memoize-one": "^6.0.0", "nullthrows": "^1.1.1", "postcss-value-parser": "^4.2.0", "styleq": "^0.1.3" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg=="],
 

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
 		"react-native-select-dropdown": "^4.0.1",
 		"react-native-svg": "15.12.1",
 		"react-native-view-shot": "~4.0.3",
-		"react-native-wallet-manager": "^2.1.0",
+		"react-native-wallet-manager": "1.1.3",
 		"react-native-web": "^0.21.2",
 		"react-native-webview": "13.15.0",
 		"react-qr-code": "^2.0.18",

--- a/src/components/Member/logged-in-view.tsx
+++ b/src/components/Member/logged-in-view.tsx
@@ -241,11 +241,13 @@ export function LoggedInView(): React.JSX.Element {
 				</Text>
 			</Pressable>
 
-			<SecurityWarningModal
-				visible={showSecurityWarning}
-				onConfirm={handleConfirmAddToWallet}
-				onCancel={handleCancelAddToWallet}
-			/>
+			{Platform.OS !== 'web' ? (
+				<SecurityWarningModal
+					visible={showSecurityWarning}
+					onConfirm={handleConfirmAddToWallet}
+					onCancel={handleCancelAddToWallet}
+				/>
+			) : null}
 		</ScrollView>
 	)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📋 Description

Opening the member page crashed with:

```
TurboModuleRegistry.getEnforcing(...): 'NativeWalletManager' could not be found
```

**Root cause:** `react-native-wallet-manager` v2.x requires React Native's New Architecture (TurboModules). The app has `newArchEnabled: false` in `app.config.json`, so the native module is never registered. v2 also calls `TurboModuleRegistry.getEnforcing` at import time, so the crash happens as soon as the member screen loads — not only when tapping "Add to Wallet".

This regression was introduced in #483 when the dependency was bumped from `1.1.3` to `^2.1.0`.

**Fix:**
- Pin `react-native-wallet-manager` back to `1.1.3`, which uses the classic `NativeModules` bridge and works with the legacy architecture.
- Only render `SecurityWarningModal` on native platforms (wallet is already hidden on web).

**Member screen registration (verified):** Both member routes are correctly registered in `src/app/_layout.tsx` with names that match expo-router's generated route tree:

| File | Stack.Screen `name` | URL |
|------|---------------------|-----|
| `(screens)/member/index.tsx` | `(screens)/member/index` | `/member` |
| `(screens)/member/office-toggle.tsx` | `(screens)/member/office-toggle` | `/member/office-toggle` |

No registration changes were needed — the crash was caused solely by the wallet-manager import, not a missing route.

**Alternative considered:** Enabling New Architecture (`newArchEnabled: true`) would also satisfy v2, but that is a much larger migration with broader compatibility risk across native dependencies.

After merging, native dev clients / store builds need a rebuild (`bun prebuild` + `bun ios` / `bun android` or EAS) so the downgraded native module is linked.

## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web
- [ ] I’ve added or updated documentation (if needed)
- [x] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

The library README explicitly states: *"react-native-wallet-manager V2 requires the new architecture/TurboModules to be enabled — for old architecture please use react-native-wallet-manager V1.1.3"*.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f340f-c0aa-7902-92f0-4bc5e658b1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f340f-c0aa-7902-92f0-4bc5e658b1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

