### PR TITLE
fix: rehydrate exam dates in calendar card after query cache restore

### DIFF
--- a/src/components/Cards/calendar-card.tsx
+++ b/src/components/Cards/calendar-card.tsx
@@ -24,7 +24,7 @@ import BaseCard from './base-card'
 
 function getCalendarCardEventKey(event: CalendarCardEvent): string {
 	if (isCalendarCardExam(event)) {
-		return `exam-${event.examData.name}-${event.examData.date.getTime()}`
+		return `exam-${event.examData.name}-${event.begin.getTime()}`
 	}
 	return event.id
 }

--- a/src/utils/calendar-utils.ts
+++ b/src/utils/calendar-utils.ts
@@ -156,6 +156,15 @@ export function isCalendarCardExam(
 	return event.isExam === true
 }
 
+/** Rehydrates Date fields after React Query persistence serializes them to strings. */
+export function normalizeExamData(exam: Exam): Exam {
+	return {
+		...exam,
+		date: new Date(exam.date),
+		enrollment: new Date(exam.enrollment)
+	}
+}
+
 /**
  * Returns the next relevant moment of an event as a timestamp.
  *
@@ -198,9 +207,9 @@ export function selectCalendarCardEvents(
 			(item): CalendarCardExamEvent => ({
 				name: item.name,
 				begin: new Date(item.begin),
-				end: item.end,
+				end: item.end != null ? new Date(item.end) : undefined,
 				isExam: true,
-				examData: item.examData
+				examData: normalizeExamData(item.examData)
 			})
 		)
 	]

--- a/src/utils/tests/calendar-utils.test.ts
+++ b/src/utils/tests/calendar-utils.test.ts
@@ -263,6 +263,28 @@ describe('calendar-utils', () => {
 			expect(calendarUtils.isCalendarCardExam(result[0])).toBe(true)
 			expect(result).toHaveLength(2)
 		})
+
+		it('rehydrates exam dates serialized by persisted React Query cache', () => {
+			const events = [makeCalendarEvent('soonEvent', '2026-06-05T00:00:00')]
+			const exams = [
+				{
+					name: 'Math',
+					begin: '2026-07-01T10:00:00.000Z' as unknown as Date,
+					examData: {
+						...makeExam('Math', '2026-07-01T10:00:00'),
+						date: '2026-07-01T10:00:00.000Z' as unknown as Date,
+						enrollment: '2026-06-01T00:00:00.000Z' as unknown as Date
+					}
+				}
+			]
+			const result = calendarUtils.selectCalendarCardEvents(events, exams, NOW)
+			expect(calendarUtils.isCalendarCardExam(result[0])).toBe(true)
+			expect(result[0].begin).toBeInstanceOf(Date)
+			expect(
+				calendarUtils.isCalendarCardExam(result[0]) &&
+					result[0].examData.date.getTime()
+			).toBe(new Date('2026-07-01T10:00:00').getTime())
+		})
 	})
 
 	describe('loadExamList', () => {


### PR DESCRIPTION
## 📋 Description

<!-- Please describe the changes you’ve made and the motivation behind them. -->

Fixes a JS crash on the dashboard calendar card when persisted React Query exam data is restored with string dates instead of Date objects. Normalizes examData dates in selectCalendarCardEvents and uses the already-normalized event.begin for list keys.

## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web
- [ ] I’ve added or updated documentation (if needed)
- [ ] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

<!-- Anything else reviewers should be aware of? -->
