### PR TITLE
fix: update StudVer quick link to THI website

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -8,7 +8,8 @@ export const primussLink =
 	'https://www3.primuss.de/cgi-bin/login/index.pl?FH=fhin'
 const moodleLink = 'https://moodle.thi.de/'
 const mailLink = 'https://outlook.office.com/'
-const studverLink = 'https://studverthi.de'
+const studverLink =
+	'https://www.thi.de/hochschule/ueber-uns/hochschulgremien/studierendenvertretung/'
 const marketplaceLink = 'https://www.thi.de/service/marketplace/'
 export const libraryLink = 'https://opac.ku.de/index-hi.html'
 export const vscoutLink = 'https://vscout.thi.de'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the StudVer quick link from `studverthi.de` (no longer available) to the official THI student representation page.

Fixes #508

## Changes

- Point `studverLink` in `src/data/constants.ts` to `https://www.thi.de/hochschule/ueber-uns/hochschulgremien/studierendenvertretung/`

## Test plan

- [ ] Open Quick Links in the app
- [ ] Tap the StudVer / Student Representation link
- [ ] Confirm it opens the THI Studierendenvertretung page
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3e4dcaf-4c05-4a66-9c9d-3e0b40f1c692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3e4dcaf-4c05-4a66-9c9d-3e0b40f1c692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

