### PR TITLE
refactor: split food detail screen into smaller modules

### DIFF
--- a/src/app/(screens)/food/[id].tsx
+++ b/src/app/(screens)/food/[id].tsx
@@ -1,9 +1,5 @@
-import { trackEvent } from '@aptabase/react-native'
-import { HeaderTitle } from '@react-navigation/elements'
-import { useQuery } from '@tanstack/react-query'
 import {
 	router,
-	Stack,
 	useFocusEffect,
 	useLocalSearchParams,
 	useNavigation
@@ -11,78 +7,46 @@ import {
 import type React from 'react'
 import { use, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import {
-	Alert,
-	Linking,
-	Platform,
-	Pressable,
-	Share,
-	Text,
-	View
-} from 'react-native'
-import Animated, {
-	interpolate,
-	useAnimatedScrollHandler,
-	useAnimatedStyle,
-	useSharedValue
-} from 'react-native-reanimated'
+import { Pressable, Text, View } from 'react-native'
+import Animated from 'react-native-reanimated'
 import { useCSSVariable } from 'uniwind'
 import { UserKindContext } from '@/components/contexts'
 import ErrorView from '@/components/Error/error-view'
+import {
+	MealDetailStackHeader,
+	useMealDetailScroll
+} from '@/components/Food/meal-detail-header'
+import { createMealPreferenceAlert } from '@/components/Food/meal-preference-alert'
+import { MealPriceRow } from '@/components/Food/meal-price-row'
 import FormList from '@/components/Universal/form-list'
-import PlatformIcon, { linkIcon } from '@/components/Universal/icon'
+import PlatformIcon from '@/components/Universal/icon'
 import LoadingIndicator from '@/components/Universal/loading-indicator'
-import allergenMap from '@/data/allergens.json'
-import { USER_EMPLOYEE, USER_GUEST, USER_STUDENT } from '@/data/constants'
-import flagMap from '@/data/mensa-flags.json'
+import { USER_GUEST } from '@/data/constants'
 import { useFoodFilterStore } from '@/hooks/useFoodFilterStore'
+import { useMealDetail } from '@/hooks/useMealDetail'
 import { useWiggleAnimation } from '@/hooks/useWiggleAnimation'
 import type { LanguageKey } from '@/localization/i18n'
-import type { FormListSections } from '@/types/components'
-import type { Meal } from '@/types/neuland-api'
 import { formatFriendlyDate } from '@/utils/date-utils'
 import {
-	formatPrice,
-	humanLocations,
-	loadFoodEntries,
+	capitalizeRestaurant,
+	foodRestaurantLocations,
 	mealName,
 	shareMeal
 } from '@/utils/food-utils'
 import { getPlatformHeaderButtons } from '@/utils/header-buttons'
-import { copyToClipboard } from '@/utils/ui-utils'
+import {
+	buildMealDetailSections,
+	getMealHumanLocation,
+	hasMealRestaurantLocation
+} from '@/utils/meal-detail-sections'
 import { hairlineBorder, toColor } from '@/utils/uniwind-utils'
-
-const foodDataSources = {
-	IngolstadtMensa: 'https://www.werkswelt.de/?id=ingo',
-	NeuburgMensa: 'https://www.werkswelt.de/?id=mtneuburg',
-	Reimanns: 'https://reimanns.in/mittagsgerichte-wochenkarte/',
-	Canisius:
-		'https://www.canisiusstiftung.de/wp-content/uploads/Speiseplan/speiseplan.pdf'
-} as const
-
-interface FoodRestaurantLocations {
-	IngolstadtMensa: string
-	Reimanns: string
-	Canisius: string
-	[key: string]: string
-}
-
-const foodRestaurantLocations: FoodRestaurantLocations = {
-	IngolstadtMensa: 'M001',
-	Reimanns: 'F001',
-	Canisius: 'X001'
-}
 
 export default function FoodDetail(): React.JSX.Element {
 	const { id } = useLocalSearchParams<{ id: string }>()
-	const textColor = toColor(useCSSVariable('--color-text'))
 	const primaryColor = toColor(useCSSVariable('--color-primary'))
 	const successColor = toColor(useCSSVariable('--color-success'))
 	const notificationColor = toColor(useCSSVariable('--color-notification'))
 	const warningColor = toColor(useCSSVariable('--color-warning'))
-	const primaryBackgroundColor = toColor(
-		useCSSVariable('--color-primary-background')
-	)
 
 	const preferencesSelection = useFoodFilterStore(
 		(state) => state.preferencesSelection
@@ -101,42 +65,16 @@ export default function FoodDetail(): React.JSX.Element {
 	const { userKind = USER_GUEST } = use(UserKindContext)
 
 	const navigation = useNavigation()
-
 	const {
-		data: queryData,
+		queryData,
 		isLoading,
-		error
-	} = useQuery({
-		queryKey: [
-			'meals',
-			['IngolstadtMensa', 'NeuburgMensa', 'Reimanns', 'Canisius'],
-			true
-		],
-		queryFn: () =>
-			loadFoodEntries(
-				['IngolstadtMensa', 'NeuburgMensa', 'Reimanns', 'Canisius'],
-				true
-			),
-		staleTime: 1000 * 60 * 5, // 5 minutes
-		gcTime: 1000 * 60 * 60 * 24 // 24 hours
-	})
-
-	// Find both the meal and its parent Food object
-	const mealWithDate = queryData?.reduce<{
-		meal: Meal | undefined
-		date: string | undefined
-	}>(
-		(acc, day) => {
-			const meal = day.meals.find((m) => m.id === id)
-			if (meal) {
-				return { meal, date: day.timestamp.toString() }
-			}
-			return acc
-		},
-		{ meal: undefined, date: undefined }
-	)
-
-	const foodData = mealWithDate?.meal
+		error,
+		meal: foodData,
+		date
+	} = useMealDetail(id)
+	const { scrollHandler, headerStyle } = useMealDetailScroll()
+	const { iconAnimatedStyle: wiggleIconAnimatedStyle, triggerWiggle } =
+		useWiggleAnimation()
 
 	useFocusEffect(
 		useCallback(() => {
@@ -155,32 +93,6 @@ export default function FoodDetail(): React.JSX.Element {
 			}
 		}, [foodData, i18n, userKind, navigation])
 	)
-	const scrollOffset = useSharedValue(0)
-	const scrollHandler = useAnimatedScrollHandler({
-		onScroll: (event) => {
-			if (scrollOffset && typeof scrollOffset.value !== 'undefined') {
-				scrollOffset.value = event.contentOffset.y
-			}
-		}
-	})
-
-	const headerStyle = useAnimatedStyle(() => {
-		return {
-			transform: [
-				{
-					translateY: interpolate(
-						scrollOffset.value,
-						[0, 30, 65],
-						[25, 25, 0],
-						'clamp'
-					)
-				}
-			]
-		}
-	})
-
-	const { iconAnimatedStyle: wiggleIconAnimatedStyle, triggerWiggle } =
-		useWiggleAnimation()
 
 	if (isLoading || !queryData) {
 		return (
@@ -199,212 +111,11 @@ export default function FoodDetail(): React.JSX.Element {
 		)
 	}
 
-	function itemAlert(item: string, itemType: 'allergen' | 'flag'): void {
-		const itemMap = itemType === 'allergen' ? allergenMap : flagMap
-		const friendlyItem =
-			itemMap[item as keyof typeof itemMap]?.[i18n.language as LanguageKey] ??
-			item
-		const isItemSelected = (
-			itemType === 'allergen' ? allergenSelection : preferencesSelection
-		).includes(item)
+	const language = i18n.language as LanguageKey
+	const restaurant = capitalizeRestaurant(foodData.restaurant)
+	const humanLocation = getMealHumanLocation(restaurant)
+	const locationExists = hasMealRestaurantLocation(restaurant)
 
-		if (Platform.OS === 'web') {
-			if (
-				!window.confirm(
-					isItemSelected
-						? t(
-								// @ts-expect-error cannot verify the TFunktion type
-								`details.formlist.alert.${itemType}.message.remove`,
-								{
-									[itemType]: friendlyItem
-								}
-							)
-						: t(
-								// @ts-expect-error cannot verify the TFunktion type
-								`details.formlist.alert.${itemType}.message.add`,
-								{
-									[itemType]: friendlyItem
-								}
-							)
-				)
-			) {
-				/* empty */
-			} else {
-				if (itemType === 'allergen') {
-					toggleSelectedAllergens(item)
-				} else if (itemType === 'flag') {
-					toggleSelectedPreferences(item)
-				}
-			}
-		} else {
-			Alert.alert(
-				t(`details.formlist.alert.${itemType}.title`),
-				isItemSelected
-					? t(
-							// @ts-expect-error cannot verify the TFunktion type
-							`details.formlist.alert.${itemType}.message.remove`,
-							{
-								[itemType]: friendlyItem
-							}
-						)
-					: t(
-							// @ts-expect-error cannot verify the TFunktion type
-							`details.formlist.alert.${itemType}.message.add`,
-							{
-								[itemType]: friendlyItem
-							}
-						),
-				[
-					{
-						text: t('misc.confirm', { ns: 'common' }),
-						onPress: () => {
-							if (itemType === 'allergen') {
-								toggleSelectedAllergens(item)
-							} else if (itemType === 'flag') {
-								toggleSelectedPreferences(item)
-							}
-						}
-					},
-					{
-						text: t('misc.cancel', { ns: 'common' }),
-						onPress: () => {
-							/* empty */
-						},
-						style: 'cancel'
-					}
-				]
-			)
-		}
-	}
-
-	const studentPrice = formatPrice(foodData?.prices?.student)
-	const employeePrice = formatPrice(foodData?.prices?.employee)
-	const guestPrice = formatPrice(foodData?.prices?.guest)
-	const isPriceAvailable =
-		studentPrice !== '' && employeePrice !== '' && guestPrice !== ''
-
-	const isNutritionAvailable =
-		foodData?.nutrition != null &&
-		Object.values(foodData.nutrition).every(
-			(value) => value !== '' && value !== 0
-		)
-
-	const nutritionSection: FormListSections[] = [
-		{
-			header: t('details.formlist.nutrition.title'),
-			footer: t('details.formlist.nutrition.footer'),
-			items: [
-				{
-					title: `${t('details.formlist.nutrition.energy')} (kJ)`,
-					value: `${(foodData?.nutrition?.kj ?? 'n/a').toString()} kJ`,
-					copyable: `${foodData?.nutrition?.kj}`
-				},
-				{
-					title: `${t('details.formlist.nutrition.energy')} (kcal)`,
-					value: `${(foodData?.nutrition?.kcal ?? 'n/a').toString()} kcal`,
-					copyable: `${foodData?.nutrition?.kcal}`
-				},
-				{
-					title: t('details.formlist.nutrition.fat'),
-					value: `${(foodData?.nutrition?.fat ?? 'n/a').toString()} g`,
-					copyable: `${foodData?.nutrition?.fat}`
-				},
-				{
-					title: t('details.formlist.nutrition.saturated'),
-					value: `${(foodData?.nutrition?.fatSaturated ?? 'n/a').toString()} g`,
-					copyable: `${foodData?.nutrition?.fatSaturated}`
-				},
-				{
-					title: t('details.formlist.nutrition.carbs'),
-					value: `${(foodData?.nutrition?.carbs ?? 'n/a').toString()} g`,
-					copyable: `${foodData?.nutrition?.carbs}`
-				},
-				{
-					title: t('details.formlist.nutrition.sugar'),
-					value: `${(foodData?.nutrition?.sugar ?? 'n/a').toString()} g`,
-					copyable: `${foodData?.nutrition?.sugar}`
-				},
-				{
-					title: t('details.formlist.nutrition.fiber'),
-					value: `${(foodData?.nutrition?.fiber ?? 'n/a').toString()} g`,
-					copyable: `${foodData?.nutrition?.fiber}`
-				},
-				{
-					title: t('details.formlist.nutrition.protein'),
-					value: `${(foodData?.nutrition?.protein ?? 'n/a').toString()} g`,
-					copyable: `${foodData?.nutrition?.protein}`
-				},
-				{
-					title: t('details.formlist.nutrition.salt'),
-					value: `${(foodData?.nutrition?.salt ?? 'n/a').toString()} g`,
-					copyable: `${foodData?.nutrition?.salt}`
-				}
-			]
-		}
-	]
-	const mensaSection: FormListSections[] = [
-		{
-			header: t('preferences.formlist.flags'),
-			items:
-				foodData?.flags?.map((flag: string) => ({
-					title:
-						flagMap[flag as keyof typeof flagMap]?.[
-							i18n.language as LanguageKey
-						] ?? flag,
-					icon: preferencesSelection.includes(flag)
-						? {
-								android: 'check_circle',
-								ios: 'checkmark.seal',
-								web: 'BadgeCheck',
-								endIcon: true
-							}
-						: undefined,
-					hideChevron: true,
-					iconColor: successColor,
-					onPress: () => {
-						itemAlert(flag, 'flag')
-					}
-				})) ?? [],
-			footer: t('details.formlist.flagsFooter')
-		},
-		{
-			header: t('preferences.formlist.allergens'),
-			items:
-				(foodData?.allergens ?? [])
-					.filter((allergen: string) =>
-						Object.keys(allergenMap).includes(allergen)
-					)
-					.map((allergen: string) => ({
-						title:
-							allergenMap[allergen as keyof typeof allergenMap]?.[
-								i18n.language as LanguageKey
-							] ?? allergen,
-						icon: allergenSelection.includes(allergen)
-							? {
-									android: 'warning',
-									ios: 'exclamationmark.triangle',
-									web: 'TriangleAlert',
-									endIcon: true
-								}
-							: undefined,
-						hideChevron: true,
-						iconColor: notificationColor,
-						onPress: () => {
-							itemAlert(allergen, 'allergen')
-						}
-					})) ?? [],
-			footer: t('details.formlist.allergenFooter', {
-				allergens: foodData?.allergens?.join(', ')
-			})
-		},
-		...(isNutritionAvailable ? nutritionSection : [])
-	]
-
-	const restaurant =
-		foodData?.restaurant != null
-			? foodData.restaurant.charAt(0).toUpperCase() +
-				foodData.restaurant.slice(1)
-			: ''
 	const handlePress = (): void => {
 		const location =
 			foodRestaurantLocations[
@@ -419,86 +130,33 @@ export default function FoodDetail(): React.JSX.Element {
 		}
 	}
 
-	const locationExists =
-		restaurant !== undefined &&
-		foodRestaurantLocations[restaurant] !== undefined
-	const humanLocation =
-		humanLocations[restaurant as keyof typeof humanLocations]
-	const humanCategory = t(
-		// @ts-expect-error cannot verify the TFunction type
-		`categories.${foodData?.category}`
-	) as string
+	const itemAlert = createMealPreferenceAlert({
+		t,
+		language,
+		allergenSelection,
+		preferencesSelection,
+		toggleSelectedAllergens,
+		toggleSelectedPreferences
+	})
 
-	const aboutSection: FormListSections[] = [
-		{
-			header: t('details.formlist.about.title'),
-			items: [
-				{
-					title: t('labels.restaurant', { ns: 'common' }),
-					value: humanLocation,
-					onPress: handlePress,
-					textColor: locationExists ? primaryColor : undefined,
-					disabled: !locationExists,
-					icon: {
-						ios: 'mappin.and.ellipse',
-						android: 'place',
-						web: 'MapPin'
-					}
-				},
-				{
-					title: t('details.formlist.about.category'),
-					value: humanCategory,
-					icon: {
-						ios: 'tag',
-						android: 'sell',
-						web: 'Tag'
-					}
-				},
-				{
-					title: t('details.formlist.about.source'),
-					icon: linkIcon,
-					onPress: () => {
-						if (foodData?.restaurant !== null) {
-							const restaurant =
-								foodData?.restaurant as keyof typeof foodDataSources
-							void Linking.openURL(foodDataSources[restaurant])
-						}
-					}
-				}
-			]
-		}
-	]
+	const sections = buildMealDetailSections({
+		foodData,
+		t,
+		language,
+		userKind,
+		restaurant,
+		humanLocation,
+		locationExists,
+		preferencesSelection,
+		allergenSelection,
+		successColor,
+		notificationColor,
+		primaryColor,
+		onItemAlert: itemAlert,
+		onNavigateToRestaurant: handlePress
+	})
 
-	const variantsSection: FormListSections[] = [
-		{
-			header: t('details.formlist.variants'),
-			items:
-				foodData?.variants?.map((variant) => ({
-					title: variant.name[i18n.language as LanguageKey],
-					value:
-						(variant?.additional ? '+ ' : '') +
-						formatPrice(variant.prices[userKind ?? USER_GUEST]),
-					onPress: () => {
-						trackEvent('Share', {
-							type: 'mealVariant'
-						})
-						const message = t('details.share.message', {
-							meal: variant.name[i18n.language as LanguageKey],
-							price: formatPrice(variant.prices[userKind ?? USER_GUEST]),
-							location: restaurant,
-							id: variant?.id
-						})
-						if (Platform.OS === 'web') {
-							void copyToClipboard(message)
-							return
-						}
-						void Share.share({
-							message
-						})
-					}
-				})) ?? []
-		}
-	]
+	const title = mealName(foodData.name, foodLanguage, language)
 
 	const isTranslated = (): boolean => {
 		if (foodLanguage !== 'default') {
@@ -507,41 +165,13 @@ export default function FoodDetail(): React.JSX.Element {
 		return i18n.language === 'de'
 	}
 
-	const sections: FormListSections[] =
-		foodData?.restaurant === 'IngolstadtMensa' ||
-		foodData?.restaurant === 'NeuburgMensa'
-			? [...variantsSection, ...mensaSection, ...aboutSection]
-			: [...variantsSection, ...aboutSection]
-
-	const title = foodData
-		? mealName(foodData.name, foodLanguage, i18n.language as LanguageKey)
-		: ''
-
 	return (
 		<Animated.ScrollView
 			contentContainerClassName="mx-page pb-bottom-safe"
 			onScroll={scrollHandler}
 			scrollEventThrottle={16}
 		>
-			<Stack.Screen
-				options={{
-					headerTitle: (props) => (
-						<View
-							className="overflow-hidden"
-							style={{
-								marginBottom: Platform.OS === 'ios' ? -10 : 0,
-								paddingRight: Platform.OS === 'ios' ? 0 : 50
-							}}
-						>
-							<Animated.View style={headerStyle}>
-								<HeaderTitle {...props} tintColor={String(textColor)}>
-									{title}
-								</HeaderTitle>
-							</Animated.View>
-						</View>
-					)
-				}}
-			/>
+			<MealDetailStackHeader title={title} headerStyle={headerStyle} />
 			<View className="flex-row items-start justify-between pb-1.5">
 				<Text
 					className="text-text flex-1 text-[22px] font-bold pt-4 text-left"
@@ -555,7 +185,7 @@ export default function FoodDetail(): React.JSX.Element {
 			</View>
 
 			<View className="flex-row gap-2 mb-4 items-center">
-				{mealWithDate?.date && (
+				{date && (
 					<View
 						className="flex-row items-center gap-1.5 bg-card-sheet px-3 py-1.5 rounded-md border-border"
 						style={hairlineBorder}
@@ -576,7 +206,7 @@ export default function FoodDetail(): React.JSX.Element {
 							style={{ color: primaryColor }}
 						/>
 						<Text className="text-text text-sm font-medium">
-							{formatFriendlyDate(mealWithDate.date)}
+							{formatFriendlyDate(date)}
 						</Text>
 					</View>
 				)}
@@ -606,79 +236,7 @@ export default function FoodDetail(): React.JSX.Element {
 				</Pressable>
 			</View>
 
-			{isPriceAvailable && (
-				<View className="flex-row gap-2 mb-4">
-					<View
-						className="flex-1 bg-card-sheet rounded-md p-3 items-center border-border"
-						style={[
-							hairlineBorder,
-							userKind === USER_STUDENT
-								? {
-										backgroundColor: primaryBackgroundColor,
-										borderColor: primaryColor
-									}
-								: undefined
-						]}
-					>
-						<Text className="text-label text-xs mb-1 text-center">
-							{t('details.formlist.prices.student')}
-						</Text>
-						<Text
-							className={`text-base font-semibold text-center ${
-								userKind === USER_STUDENT ? 'text-primary' : 'text-text'
-							}`}
-						>
-							{studentPrice}
-						</Text>
-					</View>
-					<View
-						className="flex-1 bg-card-sheet rounded-md p-3 items-center border-border"
-						style={[
-							hairlineBorder,
-							userKind === USER_EMPLOYEE
-								? {
-										backgroundColor: primaryBackgroundColor,
-										borderColor: primaryColor
-									}
-								: undefined
-						]}
-					>
-						<Text className="text-label text-xs mb-1 text-center">
-							{t('details.formlist.prices.employee')}
-						</Text>
-						<Text
-							className={`text-base font-semibold text-center ${
-								userKind === USER_EMPLOYEE ? 'text-primary' : 'text-text'
-							}`}
-						>
-							{employeePrice}
-						</Text>
-					</View>
-					<View
-						className="flex-1 bg-card-sheet rounded-md p-3 items-center border-border"
-						style={[
-							hairlineBorder,
-							userKind === USER_GUEST
-								? {
-										backgroundColor: primaryBackgroundColor,
-										borderColor: primaryColor
-									}
-								: undefined
-						]}
-					>
-						<Text className="text-label text-xs mb-1 text-center">
-							{t('details.formlist.prices.guest')}
-						</Text>
-						<Text
-							className={`text-base font-semibold text-center ${
-								userKind === USER_GUEST ? 'text-primary' : 'text-text'
-							}`}
-						>
-							{guestPrice}
-						</Text>
-					</View>
-				</View>
-			)}
+			<MealPriceRow prices={foodData.prices} userKind={userKind} />
 
 			<View className="self-center my-4 w-full">
 				<FormList sections={sections} sheet />

--- a/src/components/Food/meal-detail-header.tsx
+++ b/src/components/Food/meal-detail-header.tsx
@@ -1,0 +1,76 @@
+import { HeaderTitle } from '@react-navigation/elements'
+import { Stack } from 'expo-router'
+import { Platform, View } from 'react-native'
+import Animated, {
+	interpolate,
+	useAnimatedScrollHandler,
+	useAnimatedStyle,
+	useSharedValue
+} from 'react-native-reanimated'
+import { useCSSVariable } from 'uniwind'
+import { toColor } from '@/utils/uniwind-utils'
+
+export function useMealDetailScroll(): {
+	scrollHandler: ReturnType<typeof useAnimatedScrollHandler>
+	headerStyle: ReturnType<typeof useAnimatedStyle>
+} {
+	const scrollOffset = useSharedValue(0)
+	const scrollHandler = useAnimatedScrollHandler({
+		onScroll: (event) => {
+			if (scrollOffset && typeof scrollOffset.value !== 'undefined') {
+				scrollOffset.value = event.contentOffset.y
+			}
+		}
+	})
+
+	const headerStyle = useAnimatedStyle(() => {
+		return {
+			transform: [
+				{
+					translateY: interpolate(
+						scrollOffset.value,
+						[0, 30, 65],
+						[25, 25, 0],
+						'clamp'
+					)
+				}
+			]
+		}
+	})
+
+	return { scrollHandler, headerStyle }
+}
+
+interface MealDetailStackHeaderProps {
+	title: string
+	headerStyle: ReturnType<typeof useAnimatedStyle>
+}
+
+export function MealDetailStackHeader({
+	title,
+	headerStyle
+}: MealDetailStackHeaderProps): React.JSX.Element {
+	const textColor = toColor(useCSSVariable('--color-text'))
+
+	return (
+		<Stack.Screen
+			options={{
+				headerTitle: (props) => (
+					<View
+						className="overflow-hidden"
+						style={{
+							marginBottom: Platform.OS === 'ios' ? -10 : 0,
+							paddingRight: Platform.OS === 'ios' ? 0 : 50
+						}}
+					>
+						<Animated.View style={headerStyle}>
+							<HeaderTitle {...props} tintColor={String(textColor)}>
+								{title}
+							</HeaderTitle>
+						</Animated.View>
+					</View>
+				)
+			}}
+		/>
+	)
+}

--- a/src/components/Food/meal-preference-alert.ts
+++ b/src/components/Food/meal-preference-alert.ts
@@ -1,0 +1,104 @@
+import type { TFunction } from 'i18next'
+import { Alert, Platform } from 'react-native'
+import allergenMap from '@/data/allergens.json'
+import flagMap from '@/data/mensa-flags.json'
+import type { LanguageKey } from '@/localization/i18n'
+
+export interface MealPreferenceAlertParams {
+	t: TFunction<'food'>
+	language: LanguageKey
+	allergenSelection: string[]
+	preferencesSelection: string[]
+	toggleSelectedAllergens: (item: string) => void
+	toggleSelectedPreferences: (item: string) => void
+}
+
+export function createMealPreferenceAlert(
+	params: MealPreferenceAlertParams
+): (item: string, itemType: 'allergen' | 'flag') => void {
+	const {
+		t,
+		language,
+		allergenSelection,
+		preferencesSelection,
+		toggleSelectedAllergens,
+		toggleSelectedPreferences
+	} = params
+
+	return (item: string, itemType: 'allergen' | 'flag'): void => {
+		const itemMap = itemType === 'allergen' ? allergenMap : flagMap
+		const friendlyItem =
+			itemMap[item as keyof typeof itemMap]?.[language] ?? item
+		const isItemSelected = (
+			itemType === 'allergen' ? allergenSelection : preferencesSelection
+		).includes(item)
+
+		if (Platform.OS === 'web') {
+			if (
+				!window.confirm(
+					isItemSelected
+						? t(
+								// @ts-expect-error cannot verify the TFunktion type
+								`details.formlist.alert.${itemType}.message.remove`,
+								{
+									[itemType]: friendlyItem
+								}
+							)
+						: t(
+								// @ts-expect-error cannot verify the TFunktion type
+								`details.formlist.alert.${itemType}.message.add`,
+								{
+									[itemType]: friendlyItem
+								}
+							)
+				)
+			) {
+				/* empty */
+			} else {
+				if (itemType === 'allergen') {
+					toggleSelectedAllergens(item)
+				} else if (itemType === 'flag') {
+					toggleSelectedPreferences(item)
+				}
+			}
+		} else {
+			Alert.alert(
+				t(`details.formlist.alert.${itemType}.title`),
+				isItemSelected
+					? t(
+							// @ts-expect-error cannot verify the TFunktion type
+							`details.formlist.alert.${itemType}.message.remove`,
+							{
+								[itemType]: friendlyItem
+							}
+						)
+					: t(
+							// @ts-expect-error cannot verify the TFunktion type
+							`details.formlist.alert.${itemType}.message.add`,
+							{
+								[itemType]: friendlyItem
+							}
+						),
+				[
+					{
+						text: t('misc.confirm', { ns: 'common' }),
+						onPress: () => {
+							if (itemType === 'allergen') {
+								toggleSelectedAllergens(item)
+							} else if (itemType === 'flag') {
+								toggleSelectedPreferences(item)
+							}
+						}
+					},
+					{
+						text: t('misc.cancel', { ns: 'common' }),
+						onPress: () => {
+							/* empty */
+						},
+						style: 'cancel'
+					}
+				]
+			)
+		}
+	}
+}

--- a/src/components/Food/meal-price-row.tsx
+++ b/src/components/Food/meal-price-row.tsx
@@ -1,0 +1,107 @@
+import { useTranslation } from 'react-i18next'
+import { Text, View } from 'react-native'
+import { useCSSVariable } from 'uniwind'
+import { USER_EMPLOYEE, USER_GUEST, USER_STUDENT } from '@/data/constants'
+import type { Meal } from '@/types/neuland-api'
+import { formatPrice } from '@/utils/food-utils'
+import { hairlineBorder, toColor } from '@/utils/uniwind-utils'
+
+interface MealPriceRowProps {
+	prices: Meal['prices']
+	userKind: string
+}
+
+export function MealPriceRow({
+	prices,
+	userKind
+}: MealPriceRowProps): React.JSX.Element | null {
+	const { t } = useTranslation('food')
+	const primaryColor = toColor(useCSSVariable('--color-primary'))
+	const primaryBackgroundColor = toColor(
+		useCSSVariable('--color-primary-background')
+	)
+
+	const studentPrice = formatPrice(prices?.student)
+	const employeePrice = formatPrice(prices?.employee)
+	const guestPrice = formatPrice(prices?.guest)
+	const isPriceAvailable =
+		studentPrice !== '' && employeePrice !== '' && guestPrice !== ''
+
+	if (!isPriceAvailable) {
+		return null
+	}
+
+	return (
+		<View className="flex-row gap-2 mb-4">
+			<View
+				className="flex-1 bg-card-sheet rounded-md p-3 items-center border-border"
+				style={[
+					hairlineBorder,
+					userKind === USER_STUDENT
+						? {
+								backgroundColor: primaryBackgroundColor,
+								borderColor: primaryColor
+							}
+						: undefined
+				]}
+			>
+				<Text className="text-label text-xs mb-1 text-center">
+					{t('details.formlist.prices.student')}
+				</Text>
+				<Text
+					className={`text-base font-semibold text-center ${
+						userKind === USER_STUDENT ? 'text-primary' : 'text-text'
+					}`}
+				>
+					{studentPrice}
+				</Text>
+			</View>
+			<View
+				className="flex-1 bg-card-sheet rounded-md p-3 items-center border-border"
+				style={[
+					hairlineBorder,
+					userKind === USER_EMPLOYEE
+						? {
+								backgroundColor: primaryBackgroundColor,
+								borderColor: primaryColor
+							}
+						: undefined
+				]}
+			>
+				<Text className="text-label text-xs mb-1 text-center">
+					{t('details.formlist.prices.employee')}
+				</Text>
+				<Text
+					className={`text-base font-semibold text-center ${
+						userKind === USER_EMPLOYEE ? 'text-primary' : 'text-text'
+					}`}
+				>
+					{employeePrice}
+				</Text>
+			</View>
+			<View
+				className="flex-1 bg-card-sheet rounded-md p-3 items-center border-border"
+				style={[
+					hairlineBorder,
+					userKind === USER_GUEST
+						? {
+								backgroundColor: primaryBackgroundColor,
+								borderColor: primaryColor
+							}
+						: undefined
+				]}
+			>
+				<Text className="text-label text-xs mb-1 text-center">
+					{t('details.formlist.prices.guest')}
+				</Text>
+				<Text
+					className={`text-base font-semibold text-center ${
+						userKind === USER_GUEST ? 'text-primary' : 'text-text'
+					}`}
+				>
+					{guestPrice}
+				</Text>
+			</View>
+		</View>
+	)
+}

--- a/src/hooks/useMealDetail.ts
+++ b/src/hooks/useMealDetail.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query'
+import type { Meal } from '@/types/neuland-api'
+import { FOOD_DETAIL_RESTAURANTS, loadFoodEntries } from '@/utils/food-utils'
+
+const MEALS_STALE_TIME_MS = 1000 * 60 * 5
+const MEALS_GC_TIME_MS = 1000 * 60 * 60 * 24
+
+export interface MealWithDate {
+	meal: Meal | undefined
+	date: string | undefined
+}
+
+export function useMealDetail(id: string): {
+	queryData: Awaited<ReturnType<typeof loadFoodEntries>> | undefined
+	isLoading: boolean
+	error: Error | null
+	meal: Meal | undefined
+	date: string | undefined
+} {
+	const {
+		data: queryData,
+		isLoading,
+		error
+	} = useQuery({
+		queryKey: ['meals', FOOD_DETAIL_RESTAURANTS, true],
+		queryFn: () => loadFoodEntries([...FOOD_DETAIL_RESTAURANTS], true),
+		staleTime: MEALS_STALE_TIME_MS,
+		gcTime: MEALS_GC_TIME_MS
+	})
+
+	const mealWithDate = queryData?.reduce<MealWithDate>(
+		(acc, day) => {
+			const meal = day.meals.find((m) => m.id === id)
+			if (meal) {
+				return { meal, date: day.timestamp.toString() }
+			}
+			return acc
+		},
+		{ meal: undefined, date: undefined }
+	)
+
+	return {
+		queryData,
+		isLoading,
+		error,
+		meal: mealWithDate?.meal,
+		date: mealWithDate?.date
+	}
+}

--- a/src/utils/food-utils.ts
+++ b/src/utils/food-utils.ts
@@ -21,6 +21,36 @@ export const humanLocations = {
 	Canisius: 'Canisius Konvikt'
 }
 
+export const FOOD_DETAIL_RESTAURANTS = [
+	'IngolstadtMensa',
+	'NeuburgMensa',
+	'Reimanns',
+	'Canisius'
+] as const
+
+export const foodDataSources = {
+	IngolstadtMensa: 'https://www.werkswelt.de/?id=ingo',
+	NeuburgMensa: 'https://www.werkswelt.de/?id=mtneuburg',
+	Reimanns: 'https://reimanns.in/mittagsgerichte-wochenkarte/',
+	Canisius:
+		'https://www.canisiusstiftung.de/wp-content/uploads/Speiseplan/speiseplan.pdf'
+} as const
+
+export const foodRestaurantLocations = {
+	IngolstadtMensa: 'M001',
+	Reimanns: 'F001',
+	Canisius: 'X001'
+} as const
+
+export function capitalizeRestaurant(
+	restaurant: string | null | undefined
+): string {
+	if (restaurant == null) {
+		return ''
+	}
+	return restaurant.charAt(0).toUpperCase() + restaurant.slice(1)
+}
+
 /**
  * Fetches and parses the meal plan
  * @param {string[]} restaurants Requested restaurants

--- a/src/utils/meal-detail-sections.ts
+++ b/src/utils/meal-detail-sections.ts
@@ -1,0 +1,315 @@
+import { trackEvent } from '@aptabase/react-native'
+import type { TFunction } from 'i18next'
+import { type ColorValue, Linking, Platform, Share } from 'react-native'
+import { linkIcon } from '@/components/Universal/icon'
+import allergenMap from '@/data/allergens.json'
+import { USER_GUEST } from '@/data/constants'
+import flagMap from '@/data/mensa-flags.json'
+import type { LanguageKey } from '@/localization/i18n'
+import type { FormListSections } from '@/types/components'
+import type { Meal, Prices } from '@/types/neuland-api'
+import {
+	foodDataSources,
+	foodRestaurantLocations,
+	formatPrice,
+	humanLocations
+} from '@/utils/food-utils'
+import { copyToClipboard } from '@/utils/ui-utils'
+
+export function isMealNutritionAvailable(foodData: Meal): boolean {
+	return (
+		foodData.nutrition != null &&
+		Object.values(foodData.nutrition).every(
+			(value) => value !== '' && value !== 0
+		)
+	)
+}
+
+export function isMensaRestaurant(
+	restaurant: string | null | undefined
+): boolean {
+	return restaurant === 'IngolstadtMensa' || restaurant === 'NeuburgMensa'
+}
+
+interface MealDetailSectionsParams {
+	foodData: Meal
+	t: TFunction<'food'>
+	language: LanguageKey
+	userKind: string
+	restaurant: string
+	humanLocation: string
+	locationExists: boolean
+	preferencesSelection: string[]
+	allergenSelection: string[]
+	successColor: ColorValue | undefined
+	notificationColor: ColorValue | undefined
+	primaryColor: ColorValue | undefined
+	onItemAlert: (item: string, itemType: 'allergen' | 'flag') => void
+	onNavigateToRestaurant: () => void
+}
+
+export function buildNutritionSection(
+	foodData: Meal,
+	t: TFunction<'food'>
+): FormListSections[] {
+	return [
+		{
+			header: t('details.formlist.nutrition.title'),
+			footer: t('details.formlist.nutrition.footer'),
+			items: [
+				{
+					title: `${t('details.formlist.nutrition.energy')} (kJ)`,
+					value: `${(foodData.nutrition?.kj ?? 'n/a').toString()} kJ`,
+					copyable: `${foodData.nutrition?.kj}`
+				},
+				{
+					title: `${t('details.formlist.nutrition.energy')} (kcal)`,
+					value: `${(foodData.nutrition?.kcal ?? 'n/a').toString()} kcal`,
+					copyable: `${foodData.nutrition?.kcal}`
+				},
+				{
+					title: t('details.formlist.nutrition.fat'),
+					value: `${(foodData.nutrition?.fat ?? 'n/a').toString()} g`,
+					copyable: `${foodData.nutrition?.fat}`
+				},
+				{
+					title: t('details.formlist.nutrition.saturated'),
+					value: `${(foodData.nutrition?.fatSaturated ?? 'n/a').toString()} g`,
+					copyable: `${foodData.nutrition?.fatSaturated}`
+				},
+				{
+					title: t('details.formlist.nutrition.carbs'),
+					value: `${(foodData.nutrition?.carbs ?? 'n/a').toString()} g`,
+					copyable: `${foodData.nutrition?.carbs}`
+				},
+				{
+					title: t('details.formlist.nutrition.sugar'),
+					value: `${(foodData.nutrition?.sugar ?? 'n/a').toString()} g`,
+					copyable: `${foodData.nutrition?.sugar}`
+				},
+				{
+					title: t('details.formlist.nutrition.fiber'),
+					value: `${(foodData.nutrition?.fiber ?? 'n/a').toString()} g`,
+					copyable: `${foodData.nutrition?.fiber}`
+				},
+				{
+					title: t('details.formlist.nutrition.protein'),
+					value: `${(foodData.nutrition?.protein ?? 'n/a').toString()} g`,
+					copyable: `${foodData.nutrition?.protein}`
+				},
+				{
+					title: t('details.formlist.nutrition.salt'),
+					value: `${(foodData.nutrition?.salt ?? 'n/a').toString()} g`,
+					copyable: `${foodData.nutrition?.salt}`
+				}
+			]
+		}
+	]
+}
+
+export function buildMensaSection(
+	params: MealDetailSectionsParams
+): FormListSections[] {
+	const {
+		foodData,
+		t,
+		language,
+		preferencesSelection,
+		allergenSelection,
+		successColor,
+		notificationColor,
+		onItemAlert
+	} = params
+
+	const nutritionSection = isMealNutritionAvailable(foodData)
+		? buildNutritionSection(foodData, t)
+		: []
+
+	return [
+		{
+			header: t('preferences.formlist.flags'),
+			items:
+				foodData.flags?.map((flag: string) => ({
+					title: flagMap[flag as keyof typeof flagMap]?.[language] ?? flag,
+					icon: preferencesSelection.includes(flag)
+						? {
+								android: 'check_circle',
+								ios: 'checkmark.seal',
+								web: 'BadgeCheck',
+								endIcon: true
+							}
+						: undefined,
+					hideChevron: true,
+					iconColor: successColor,
+					onPress: () => {
+						onItemAlert(flag, 'flag')
+					}
+				})) ?? [],
+			footer: t('details.formlist.flagsFooter')
+		},
+		{
+			header: t('preferences.formlist.allergens'),
+			items:
+				(foodData.allergens ?? [])
+					.filter((allergen: string) =>
+						Object.keys(allergenMap).includes(allergen)
+					)
+					.map((allergen: string) => ({
+						title:
+							allergenMap[allergen as keyof typeof allergenMap]?.[language] ??
+							allergen,
+						icon: allergenSelection.includes(allergen)
+							? {
+									android: 'warning',
+									ios: 'exclamationmark.triangle',
+									web: 'TriangleAlert',
+									endIcon: true
+								}
+							: undefined,
+						hideChevron: true,
+						iconColor: notificationColor,
+						onPress: () => {
+							onItemAlert(allergen, 'allergen')
+						}
+					})) ?? [],
+			footer: t('details.formlist.allergenFooter', {
+				allergens: foodData.allergens?.join(', ')
+			})
+		},
+		...nutritionSection
+	]
+}
+
+export function buildAboutSection(
+	params: MealDetailSectionsParams
+): FormListSections[] {
+	const {
+		foodData,
+		t,
+		humanLocation,
+		locationExists,
+		primaryColor,
+		onNavigateToRestaurant
+	} = params
+
+	const humanCategory = t(
+		// @ts-expect-error cannot verify the TFunction type
+		`categories.${foodData.category}`
+	) as string
+
+	return [
+		{
+			header: t('details.formlist.about.title'),
+			items: [
+				{
+					title: t('labels.restaurant', { ns: 'common' }),
+					value: humanLocation,
+					onPress: onNavigateToRestaurant,
+					textColor: locationExists ? primaryColor : undefined,
+					disabled: !locationExists,
+					icon: {
+						ios: 'mappin.and.ellipse',
+						android: 'place',
+						web: 'MapPin'
+					}
+				},
+				{
+					title: t('details.formlist.about.category'),
+					value: humanCategory,
+					icon: {
+						ios: 'tag',
+						android: 'sell',
+						web: 'Tag'
+					}
+				},
+				{
+					title: t('details.formlist.about.source'),
+					icon: linkIcon,
+					onPress: () => {
+						if (foodData.restaurant !== null) {
+							const restaurant =
+								foodData.restaurant as keyof typeof foodDataSources
+							void Linking.openURL(foodDataSources[restaurant])
+						}
+					}
+				}
+			]
+		}
+	]
+}
+
+export function buildVariantsSection(
+	foodData: Meal,
+	t: TFunction<'food'>,
+	language: LanguageKey,
+	userKind: string,
+	restaurant: string
+): FormListSections[] {
+	return [
+		{
+			header: t('details.formlist.variants'),
+			items:
+				foodData.variants?.map((variant) => {
+					const priceKey = (userKind ?? USER_GUEST) as keyof Prices
+					return {
+						title: variant.name[language],
+						value:
+							(variant?.additional ? '+ ' : '') +
+							formatPrice(variant.prices[priceKey]),
+						onPress: () => {
+							trackEvent('Share', {
+								type: 'mealVariant'
+							})
+							const message = t('details.share.message', {
+								meal: variant.name[language],
+								price: formatPrice(variant.prices[priceKey]),
+								location: restaurant,
+								id: variant?.id
+							})
+							if (Platform.OS === 'web') {
+								void copyToClipboard(message)
+								return
+							}
+							void Share.share({
+								message
+							})
+						}
+					}
+				}) ?? []
+		}
+	]
+}
+
+export function buildMealDetailSections(
+	params: MealDetailSectionsParams
+): FormListSections[] {
+	const { foodData, t, language, userKind, restaurant } = params
+
+	const variantsSection = buildVariantsSection(
+		foodData,
+		t,
+		language,
+		userKind,
+		restaurant
+	)
+	const aboutSection = buildAboutSection(params)
+
+	if (isMensaRestaurant(foodData.restaurant)) {
+		return [...variantsSection, ...buildMensaSection(params), ...aboutSection]
+	}
+
+	return [...variantsSection, ...aboutSection]
+}
+
+export function getMealHumanLocation(restaurant: string): string {
+	return humanLocations[restaurant as keyof typeof humanLocations]
+}
+
+export function hasMealRestaurantLocation(restaurant: string): boolean {
+	return (
+		restaurant !== undefined &&
+		foodRestaurantLocations[
+			restaurant as keyof typeof foodRestaurantLocations
+		] !== undefined
+	)
+}

--- a/src/utils/tests/food-utils.test.ts
+++ b/src/utils/tests/food-utils.test.ts
@@ -159,6 +159,13 @@ describe('food-utils', () => {
 		expect(foodUtils.formatPrice(undefined)).toBe('')
 	})
 
+	it('capitalizeRestaurant - Should capitalize the restaurant name', () => {
+		expect(foodUtils.capitalizeRestaurant('ingolstadtMensa')).toBe(
+			'IngolstadtMensa'
+		)
+		expect(foodUtils.capitalizeRestaurant(null)).toBe('')
+	})
+
 	it('getUserSpecificPrice - Should select the guest price', () => {
 		const meal = {
 			prices: {

--- a/src/utils/tests/meal-detail-sections.test.ts
+++ b/src/utils/tests/meal-detail-sections.test.ts
@@ -1,0 +1,334 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import type { TFunction } from 'i18next'
+import type { Meal } from '@/types/neuland-api'
+
+const SRC_ROOT = new URL('../../', import.meta.url).pathname
+
+const platform = { OS: 'web' as 'web' | 'ios' | 'android' }
+const shareMock = mock(async () => {})
+const openUrlMock = mock(async () => {})
+const clipboardSetStringAsyncMock = mock(async () => {})
+const trackEventMock = mock(() => {})
+const mockGetFoodPlan = mock(
+	async (): Promise<{ food: unknown }> => ({ food: [] })
+)
+const mockGetFragmentData = mock(() => ({ foodData: [] as unknown[] }))
+
+mock.module(`${SRC_ROOT}localization/i18n.ts`, () => ({
+	default: { language: 'de' }
+}))
+
+mock.module('expo-localization', () => ({
+	getLocales: () => [{ languageCode: 'de' }]
+}))
+
+mock.module('react-i18next', () => ({
+	initReactI18next: {}
+}))
+
+mock.module('react-native', () => ({
+	__esModule: true,
+	default: {
+		Platform: platform,
+		Share: { share: shareMock },
+		Linking: { openURL: openUrlMock },
+		NativeEventEmitter: class {
+			addListener() {
+				return { remove: () => {} }
+			}
+			removeAllListeners() {}
+		},
+		TurboModuleRegistry: {
+			get: () => null,
+			getEnforcing: () => null
+		}
+	},
+	Platform: platform,
+	Share: { share: shareMock },
+	Linking: { openURL: openUrlMock },
+	NativeEventEmitter: class {
+		addListener() {
+			return { remove: () => {} }
+		}
+		removeAllListeners() {}
+	},
+	TurboModuleRegistry: {
+		get: () => null,
+		getEnforcing: () => null
+	}
+}))
+
+mock.module('@aptabase/react-native', () => ({
+	trackEvent: trackEventMock
+}))
+
+mock.module('expo-clipboard', () => ({
+	setStringAsync: clipboardSetStringAsyncMock
+}))
+
+mock.module('burnt', () => ({
+	toast: () => {}
+}))
+
+mock.module(`${SRC_ROOT}__generated__/gql/graphql.ts`, () => ({
+	FoodFieldsFragmentDoc: {},
+	UniversitySportsFieldsFragmentDoc: {}
+}))
+
+mock.module(`${SRC_ROOT}__generated__/gql/index.ts`, () => ({
+	getFragmentData: mockGetFragmentData
+}))
+
+mock.module(`${SRC_ROOT}api/neuland-api.ts`, () => ({
+	default: {
+		getFoodPlan: mockGetFoodPlan
+	}
+}))
+
+mock.module(`${SRC_ROOT}components/Universal/icon.tsx`, () => ({
+	linkIcon: {
+		ios: 'link',
+		android: 'link',
+		web: 'Link'
+	}
+}))
+
+let mealDetailSections: typeof import('../meal-detail-sections')
+
+const t = ((key: string, options?: { ns?: string; [key: string]: unknown }) => {
+	if (options?.ns === 'common') {
+		return `common:${key}`
+	}
+	if (key === 'details.formlist.allergenFooter') {
+		return `allergens:${options?.allergens}`
+	}
+	if (key === 'details.share.message') {
+		return `share:${options?.meal}:${options?.price}:${options?.location}:${options?.id}`
+	}
+	return key
+}) as TFunction<'food'>
+
+const makeMeal = (overrides: Partial<Meal> = {}): Meal =>
+	({
+		id: 'meal-1',
+		static: false,
+		name: { de: 'Gericht', en: 'Meal' },
+		category: 'Hauptgericht',
+		prices: { guest: 4.5, employee: 3.5, student: 2.5 },
+		allergens: ['Ei'],
+		flags: ['V'],
+		nutrition: {
+			kj: 1000,
+			kcal: 240,
+			fat: 10,
+			fatSaturated: 3,
+			carbs: 20,
+			sugar: 5,
+			fiber: 2,
+			protein: 12,
+			salt: 1
+		},
+		variants: [
+			{
+				id: 'variant-1',
+				additional: true,
+				name: { de: 'Groß', en: 'Large' },
+				prices: { guest: 1, employee: 1, student: 1 }
+			}
+		],
+		originalLanguage: 'de',
+		restaurant: 'IngolstadtMensa',
+		...overrides
+	}) as Meal
+
+const baseParams = () => ({
+	foodData: makeMeal(),
+	t,
+	language: 'de' as const,
+	userKind: 'student',
+	restaurant: 'IngolstadtMensa',
+	humanLocation: 'Mensa Ingolstadt',
+	locationExists: true,
+	preferencesSelection: ['V'],
+	allergenSelection: [] as string[],
+	successColor: '#00ff00',
+	notificationColor: '#ff0000',
+	primaryColor: '#007aff',
+	onItemAlert: mock(() => {}),
+	onNavigateToRestaurant: mock(() => {})
+})
+
+beforeAll(async () => {
+	mealDetailSections = await import('../meal-detail-sections')
+})
+
+describe('meal-detail-sections', () => {
+	it('isMealNutritionAvailable - Should return true when all nutrition values are present', () => {
+		expect(mealDetailSections.isMealNutritionAvailable(makeMeal())).toBe(true)
+	})
+
+	it('isMealNutritionAvailable - Should return false when nutrition is missing or empty', () => {
+		expect(
+			mealDetailSections.isMealNutritionAvailable(makeMeal({ nutrition: null }))
+		).toBe(false)
+		expect(
+			mealDetailSections.isMealNutritionAvailable(
+				makeMeal({
+					nutrition: {
+						kj: 0,
+						kcal: 240,
+						fat: 10,
+						fatSaturated: 3,
+						carbs: 20,
+						sugar: 5,
+						fiber: 2,
+						protein: 12,
+						salt: 1
+					}
+				})
+			)
+		).toBe(false)
+	})
+
+	it('isMensaRestaurant - Should identify mensa restaurants', () => {
+		expect(mealDetailSections.isMensaRestaurant('IngolstadtMensa')).toBe(true)
+		expect(mealDetailSections.isMensaRestaurant('NeuburgMensa')).toBe(true)
+		expect(mealDetailSections.isMensaRestaurant('Reimanns')).toBe(false)
+	})
+
+	it('getMealHumanLocation - Should resolve known restaurant labels', () => {
+		expect(mealDetailSections.getMealHumanLocation('IngolstadtMensa')).toBe(
+			'Mensa Ingolstadt'
+		)
+	})
+
+	it('hasMealRestaurantLocation - Should detect mapped restaurant locations', () => {
+		expect(
+			mealDetailSections.hasMealRestaurantLocation('IngolstadtMensa')
+		).toBe(true)
+		expect(mealDetailSections.hasMealRestaurantLocation('Reimanns')).toBe(true)
+		expect(mealDetailSections.hasMealRestaurantLocation('Unknown')).toBe(false)
+	})
+
+	it('buildMealDetailSections - Should include mensa sections for mensa restaurants', () => {
+		const sections = mealDetailSections.buildMealDetailSections(baseParams())
+		const headers = sections.map((section) => section.header)
+
+		expect(headers).toContain('details.formlist.variants')
+		expect(headers).toContain('preferences.formlist.flags')
+		expect(headers).toContain('preferences.formlist.allergens')
+		expect(headers).toContain('details.formlist.nutrition.title')
+		expect(headers).toContain('details.formlist.about.title')
+	})
+
+	it('buildMealDetailSections - Should omit mensa sections for non-mensa restaurants', () => {
+		const params = {
+			...baseParams(),
+			foodData: makeMeal({ restaurant: 'Reimanns' }),
+			restaurant: 'Reimanns'
+		}
+		const sections = mealDetailSections.buildMealDetailSections(params)
+		const headers = sections.map((section) => section.header)
+
+		expect(headers).toContain('details.formlist.variants')
+		expect(headers).toContain('details.formlist.about.title')
+		expect(headers).not.toContain('preferences.formlist.flags')
+	})
+
+	it('buildMensaSection - Should wire allergen and flag presses to onItemAlert', () => {
+		const onItemAlert = mock(() => {})
+		const sections = mealDetailSections.buildMensaSection({
+			...baseParams(),
+			onItemAlert
+		})
+
+		const flagItem = sections[0]?.items?.[0]
+		const allergenItem = sections[1]?.items?.[0]
+
+		flagItem?.onPress?.()
+		allergenItem?.onPress?.()
+
+		expect(onItemAlert).toHaveBeenCalledWith('V', 'flag')
+		expect(onItemAlert).toHaveBeenCalledWith('Ei', 'allergen')
+	})
+
+	it('buildMensaSection - Should mark selected allergens and flags with icons', () => {
+		const sections = mealDetailSections.buildMensaSection({
+			...baseParams(),
+			allergenSelection: ['Ei']
+		})
+
+		expect(sections[0]?.items?.[0]?.icon).toBeDefined()
+		expect(sections[1]?.items?.[0]?.icon).toBeDefined()
+	})
+
+	it('buildAboutSection - Should navigate to restaurant and open source link', () => {
+		const onNavigateToRestaurant = mock(() => {})
+		const sections = mealDetailSections.buildAboutSection({
+			...baseParams(),
+			onNavigateToRestaurant
+		})
+
+		const restaurantItem = sections[0]?.items?.[0]
+		const sourceItem = sections[0]?.items?.[2]
+
+		restaurantItem?.onPress?.()
+		sourceItem?.onPress?.()
+
+		expect(onNavigateToRestaurant).toHaveBeenCalled()
+		expect(openUrlMock).toHaveBeenCalledWith(
+			'https://www.werkswelt.de/?id=ingo'
+		)
+	})
+
+	it('buildVariantsSection - Should copy variant share message on web', () => {
+		platform.OS = 'web'
+		trackEventMock.mockReset()
+		clipboardSetStringAsyncMock.mockReset()
+		shareMock.mockReset()
+
+		const sections = mealDetailSections.buildVariantsSection(
+			makeMeal(),
+			t,
+			'de',
+			'student',
+			'IngolstadtMensa'
+		)
+
+		sections[0]?.items?.[0]?.onPress?.()
+
+		expect(trackEventMock).toHaveBeenCalledWith('Share', {
+			type: 'mealVariant'
+		})
+		expect(clipboardSetStringAsyncMock).toHaveBeenCalledWith(
+			'share:Groß:1.00 €:IngolstadtMensa:variant-1'
+		)
+		expect(shareMock).not.toHaveBeenCalled()
+
+		platform.OS = 'web'
+	})
+
+	it('buildVariantsSection - Should use native share sheet off web', () => {
+		platform.OS = 'ios'
+		trackEventMock.mockReset()
+		clipboardSetStringAsyncMock.mockReset()
+		shareMock.mockReset()
+
+		const sections = mealDetailSections.buildVariantsSection(
+			makeMeal(),
+			t,
+			'de',
+			'guest',
+			'IngolstadtMensa'
+		)
+
+		sections[0]?.items?.[0]?.onPress?.()
+
+		expect(shareMock).toHaveBeenCalledWith({
+			message: 'share:Groß:1.00 €:IngolstadtMensa:variant-1'
+		})
+		expect(clipboardSetStringAsyncMock).not.toHaveBeenCalled()
+
+		platform.OS = 'web'
+	})
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Splits the food detail screen (`food/[id].tsx`, 720 → 278 lines) into focused modules. No behavior or UI changes.

**Extracted:**
- `useMealDetail` — query + meal lookup
- `meal-detail-sections.ts` — FormList section builders
- `meal-preference-alert.ts` — allergen/flag confirmation dialogs
- `meal-detail-header.tsx` — Reanimated stack header
- `meal-price-row.tsx` — price chips
- Restaurant constants → `food-utils.ts`

**Tests added** for extracted utils (`meal-detail-sections.test.ts`, `capitalizeRestaurant` in `food-utils.test.ts`) to restore Codecov patch coverage.

## Checklist

- [x] `bun tsc --noEmit`
- [x] `bun lint`
- [x] `bun test --ci` (273 tests)
- [x] `bun i18n:check`
- [x] `bun run test:coverage` — `meal-detail-sections.ts` and `food-utils.ts` at 100% line coverage

## Test plan

- [ ] Food detail: prices, allergens/flags, share, map link

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85d584c3-14b3-48af-81f6-43c7f107b238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85d584c3-14b3-48af-81f6-43c7f107b238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

