### PR TITLE
fix: update calendar semester dates link URLs

### DIFF
--- a/src/data/calendar.json
+++ b/src/data/calendar.json
@@ -2,7 +2,8 @@
 	"comments": [
 		"If you work on this file, please triple-check if you entered all days correctly.",
 		"Incorrect entries might get people in trouble.",
-		"Also, please do not remove this warning."
+		"Also, please do not remove this warning.",
+		"Official source: https://www.thi.de/studium/semestertermine/ (PDF per semester linked there)."
 	],
 	"semesters": [
 		{

--- a/src/data/calendar.json
+++ b/src/data/calendar.json
@@ -2,8 +2,7 @@
 	"comments": [
 		"If you work on this file, please triple-check if you entered all days correctly.",
 		"Incorrect entries might get people in trouble.",
-		"Also, please do not remove this warning.",
-		"Official source: https://www.thi.de/studium/semestertermine/ (PDF per semester linked there)."
+		"Also, please do not remove this warning."
 	],
 	"semesters": [
 		{

--- a/src/localization/de/common.json
+++ b/src/localization/de/common.json
@@ -168,16 +168,16 @@
 				"title": "Termine"
 			},
 			"calendar": {
-				"link": "https://www.thi.de/studium/pruefung/semestertermine/",
+				"link": "https://www.thi.de/studium/semestertermine/",
 				"noData": {
 					"title": "Keine Daten gefunden",
 					"subtitle": "Bitte versuche es später erneut."
 				}
 			},
 			"footer": {
-				"part1": "Alle Informationen ohne Gewähr. Verbindliche Informationen sind direkt auf der ",
-				"part2": "Universitätswebsite",
-				"part3": " verfügbar."
+				"part1": "Die Semestertermine stammen aus den offiziellen Angaben der THI (PDFs auf der ",
+				"part2": "Semestertermine-Seite der THI",
+				"part3": "). Alle Informationen ohne Gewähr. Verbindliche Angaben sind nur dort verfügbar."
 			}
 		},
 		"lecturers": {

--- a/src/localization/de/common.json
+++ b/src/localization/de/common.json
@@ -175,9 +175,9 @@
 				}
 			},
 			"footer": {
-				"part1": "Die Semestertermine stammen aus den offiziellen Angaben der THI (PDFs auf der ",
-				"part2": "Semestertermine-Seite der THI",
-				"part3": "). Alle Informationen ohne Gewähr. Verbindliche Angaben sind nur dort verfügbar."
+				"part1": "Alle Informationen ohne Gewähr. Verbindliche Informationen sind direkt auf der ",
+				"part2": "Universitätswebsite",
+				"part3": " verfügbar."
 			}
 		},
 		"lecturers": {

--- a/src/localization/en/common.json
+++ b/src/localization/en/common.json
@@ -168,16 +168,16 @@
 				"title": "Dates"
 			},
 			"calendar": {
-				"link": "https://www.thi.de/en/international/studies/examination/semester-dates/",
+				"link": "https://www.thi.de/en/studies/semester-dates/",
 				"noData": {
 					"title": "No data found",
 					"subtitle": "Please try again later."
 				}
 			},
 			"footer": {
-				"part1": "All information without guarantee. Binding information is only available directly on the ",
-				"part2": "university website",
-				"part3": "."
+				"part1": "Semester dates are based on the official THI schedule (PDFs on the ",
+				"part2": "THI semester dates page",
+				"part3": "). All information without guarantee. Binding information is only available there."
 			}
 		},
 		"lecturers": {

--- a/src/localization/en/common.json
+++ b/src/localization/en/common.json
@@ -175,9 +175,9 @@
 				}
 			},
 			"footer": {
-				"part1": "Semester dates are based on the official THI schedule (PDFs on the ",
-				"part2": "THI semester dates page",
-				"part3": "). All information without guarantee. Binding information is only available there."
+				"part1": "All information without guarantee. Binding information is only available directly on the ",
+				"part2": "university website",
+				"part3": "."
 			}
 		},
 		"lecturers": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the calendar footer link URLs to the current official THI semester dates pages. Footer copy is unchanged.

## Changes

- German link: `https://www.thi.de/studium/semestertermine/`
- English link: `https://www.thi.de/en/studies/semester-dates/`

## Test plan

- [x] `bun i18n:check`
- [ ] Open Calendar → Dates tab and verify footer link opens the correct THI page (de/en)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f45d5-5b36-722e-bae3-adc13687c8b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f45d5-5b36-722e-bae3-adc13687c8b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

