### PR TITLE
fix: exclude expo-managed devDependencies from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,7 +39,6 @@
 		{
 			"description": "Expo SDK packages managed by bun pkgs (expo install --check)",
 			"matchManagers": ["bun"],
-			"matchDepTypes": ["dependencies"],
 			"matchPackageNames": [
 				"expo",
 				"expo-*",
@@ -48,6 +47,11 @@
 				"react-dom",
 				"react-native",
 				"metro",
+				"typescript",
+				"@babel/core",
+				"@types/react",
+				"@types/react-dom",
+				"@types/jest",
 				"@react-native-community/datetimepicker",
 				"@react-native-community/netinfo",
 				"react-native-gesture-handler",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Renovate was proposing updates for `@types/react` and `@types/react-dom` even though those versions are managed by `bun pkgs` (`expo install --check`).

The Expo SDK package rule in `renovate.json` only matched `dependencies`, but `@types/react`, `@types/react-dom`, `typescript`, and `@babel/core` live in `devDependencies` and are versioned by Expo's SDK compatibility map.

## Changes

- Remove `matchDepTypes: ["dependencies"]` so the Expo rule applies regardless of dependency type (still scoped by `matchPackageNames`).
- Add `@types/react`, `@types/react-dom`, `@types/jest`, `typescript`, and `@babel/core` to the excluded package list.

These continue to be synced by the weekly **Expo SDK dependencies** workflow (`expo install --fix`).

## Checklist

- [x] Config-only change — no runtime impact
- [ ] Close any open Renovate PRs for `@types/react` / `@types/react-dom` after merge

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fd87f57-6636-4471-a73c-38080758561b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd87f57-6636-4471-a73c-38080758561b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

