### PR TITLE
ci: run unit and mutation tests on dependency prs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
     if: |
       github.event_name != 'pull_request' ||
       needs.changes.outputs.src == 'true' ||
+      needs.changes.outputs.dependencies == 'true' ||
       needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -118,6 +119,7 @@ jobs:
     if: |
       github.event_name != 'pull_request' ||
       needs.changes.outputs.src == 'true' ||
+      needs.changes.outputs.dependencies == 'true' ||
       needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Branch protection requires **Unit tests** and **Mutation tests** to pass before merge. Since #463, those jobs are skipped on PRs that only change `package.json` / `bun.lock` — which is exactly what Renovate PRs do.

GitHub treats skipped required checks as **not satisfied**, so Renovate PRs get stuck even when the code is fine.

## Fix

Run unit and mutation tests when the `dependencies` path filter matches (same trigger as Expo Doctor).

## Trade-off

Dependency-only PRs take longer in CI, but they can actually merge under branch protection rules.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-debeec2b-559a-4364-bd3b-a96194ccb59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-debeec2b-559a-4364-bd3b-a96194ccb59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

