### PR TITLE
fix: use short fingerprint digests in stale dev client issue

### DIFF
--- a/.github/workflows/fingerprint.yml
+++ b/.github/workflows/fingerprint.yml
@@ -116,11 +116,24 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Create or update stale dev client issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: Summarize fingerprint
+        id: fingerprint-summary
         env:
           CURRENT_FINGERPRINT: ${{ needs.fingerprint.outputs.current-fingerprint }}
           PREVIOUS_FINGERPRINT: ${{ needs.fingerprint.outputs.previous-fingerprint }}
+        run: |
+          echo "current-digest=$(printf '%s' "$CURRENT_FINGERPRINT" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
+          if [ -n "$PREVIOUS_FINGERPRINT" ]; then
+            echo "previous-digest=$(printf '%s' "$PREVIOUS_FINGERPRINT" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
+          else
+            echo "previous-digest=n/a" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update stale dev client issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CURRENT_DIGEST: ${{ steps.fingerprint-summary.outputs.current-digest }}
+          PREVIOUS_DIGEST: ${{ steps.fingerprint-summary.outputs.previous-digest }}
         with:
           script: |
             const staleLabel = 'dev-client-stale'
@@ -138,10 +151,12 @@ jobs:
               '| | |',
               '|---|---|',
               `| Commit | [\`${context.sha.slice(0, 7)}\`](${commitUrl}) |`,
-              `| Current fingerprint | \`${process.env.CURRENT_FINGERPRINT}\` |`,
-              `| Previous fingerprint | \`${process.env.PREVIOUS_FINGERPRINT || 'n/a'}\` |`,
+              `| Current fingerprint | \`${process.env.CURRENT_DIGEST}\` |`,
+              `| Previous fingerprint | \`${process.env.PREVIOUS_DIGEST}\` |`,
               `| Detected | ${new Date().toISOString()} |`,
               `| Fingerprint check | [workflow run](${fingerprintRunUrl}) |`,
+              '',
+              'Fingerprint digests are SHA-256 prefixes. Open the workflow run for the full Expo fingerprint output.',
               '',
               '### Rebuild',
               '',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📋 Description

The previous fix (#a3d2e28c) removed the fingerprint diff from the stale dev client issue body, but the alert job still failed because the full `current-fingerprint` and `previous-fingerprint` outputs were embedded in the issue table. Those Expo fingerprint strings alone exceed GitHub's 65k issue body limit.

This change hashes both fingerprints in a separate workflow step and only writes 12-character SHA-256 prefixes into the issue. The workflow run link remains the place to inspect the full fingerprint output.

## ✅ Checklist

- [ ] I've tested my changes on iOS
- [ ] I've tested my changes on Android
- [ ] I've tested my changes on Web
- [ ] I've added or updated documentation (if needed)
- [x] I've reviewed the related issues, if any

## 🗒️ Additional Notes

After merge, the next native fingerprint change on `main` should create or update the `dev-client-stale` issue successfully. The last three fingerprint-changing pushes all failed with `body is too long`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7739-24d4-75b4-9958-71dbadc03788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7739-24d4-75b4-9958-71dbadc03788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

