### PR TITLE
ci: ignore .claude directory in Stryker sandbox

### DIFF
--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -34,6 +34,7 @@ const config = {
 		'config',
 		'.github',
 		'.agents',
+		'.claude',
 		'patches',
 		'CHANGELOG.md'
 	],


### PR DESCRIPTION
The `.claude/skills/argent-device-interact` directory introduced in `main` causes Stryker's sandbox creation to fail with `EISDIR` because `copyFile` cannot handle directories.

**Fix**: Add `.claude` to Stryker's `ignorePatterns` so it is excluded from the sandbox copy.