### PR TITLE
chore: centralize app version

### DIFF
--- a/src/api/anonymous-api.ts
+++ b/src/api/anonymous-api.ts
@@ -1,12 +1,11 @@
 import { Platform } from 'react-native'
-
-import packageInfo from '../../package.json'
+import { appHomepage, appVersion } from '@/data/app-version'
 
 const ENDPOINT_HOST =
 	process.env.EXPO_PUBLIC_ENDPOINT_HOST ?? 'https://hiplan.thi.de'
 const ENDPOINT_URL =
 	process.env.EXPO_PUBLIC_ENDPOINT_URL ?? '/webservice/zits_s_40_test/index.php'
-const USER_AGENT = `neuland.app-native/${packageInfo.version} (+${packageInfo.homepage})`
+const USER_AGENT = `neuland.app-native/${appVersion} (+${appHomepage})`
 
 /**
  * Error that is thrown when the API indicates an error.

--- a/src/api/external-api.ts
+++ b/src/api/external-api.ts
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native'
-import packageInfo from '../../package.json'
+import { appHomepage, appVersion } from '@/data/app-version'
 
-const USER_AGENT = `neuland.app-native/${packageInfo.version} (+${packageInfo.homepage})`
+const USER_AGENT = `neuland.app-native/${appVersion} (+${appHomepage})`
 
 class ExternalAPIClient {
 	async fetchLicenseText(url: string): Promise<string> {

--- a/src/api/member-api.ts
+++ b/src/api/member-api.ts
@@ -1,9 +1,9 @@
 import { Platform } from 'react-native'
-import packageInfo from '../../package.json'
+import { appHomepage, appVersion } from '@/data/app-version'
 
 const ID_API_BASE = 'https://id.neuland-ingolstadt.de/api'
 const AUTH_TOKEN_ENDPOINT = 'https://auth.neuland.ing/application/o/token/'
-const USER_AGENT = `neuland.app-native/${packageInfo.version} (+${packageInfo.homepage})`
+const USER_AGENT = `neuland.app-native/${appVersion} (+${appHomepage})`
 
 export const AUTH_DISCOVERY = {
 	authorizationEndpoint: 'https://auth.neuland.ing/application/o/authorize/',

--- a/src/api/neuland-api.ts
+++ b/src/api/neuland-api.ts
@@ -8,6 +8,7 @@ import type {
 	TypedDocumentString,
 	UniversitySportsQuery
 } from '@/__generated__/gql/graphql'
+import { appHomepage, appVersion } from '@/data/app-version'
 import type { SpoWeights } from '@/types/asset-api'
 import {
 	CAMPUS_LIFE_PUBLIC_ORGANIZER_KIND_STUDENT_ASSOCIATION,
@@ -15,7 +16,6 @@ import {
 	type PublicEventResponse,
 	type PublicOrganizerResponse
 } from '@/types/campus-life'
-import packageInfo from '../../package.json'
 import {
 	ANNOUNCEMENT_QUERY,
 	CREATE_ROOM_REPORT,
@@ -29,7 +29,7 @@ const GRAPHQL_ENDPOINT: string =
 const GRAPHQL_ENDPOINT_PROD = 'https://api.neuland.app/graphql'
 const ASSET_ENDPOINT = 'https://assets.neuland.app'
 const CAMPUS_LIFE_API_ENDPOINT = 'https://cl.neuland-ingolstadt.de'
-const USER_AGENT = `neuland.app-native/${packageInfo.version} (+${packageInfo.homepage})`
+const USER_AGENT = `neuland.app-native/${appVersion} (+${appHomepage})`
 
 /**
  * Neuland API client class for performing requests against the neuland.app API

--- a/src/app/(screens)/grades.tsx
+++ b/src/app/(screens)/grades.tsx
@@ -19,6 +19,7 @@ import ErrorView from '@/components/Error/error-view'
 import GradesRow from '@/components/Rows/grades-row'
 import LoadingIndicator from '@/components/Universal/loading-indicator'
 import SectionView from '@/components/Universal/sections-view'
+import { appVersion } from '@/data/app-version'
 import { useRefreshByUser } from '@/hooks'
 import type { Grade } from '@/types/thi-api'
 import type { GradeAverage } from '@/types/utils'
@@ -30,8 +31,6 @@ import {
 import { loadGradeAverage, loadGrades } from '@/utils/grades-utils'
 import { LoadingState } from '@/utils/ui-utils'
 import { toColor } from '@/utils/uniwind-utils'
-
-import packageInfo from '../../../package.json'
 
 function getGradeKey(grade: Grade): string {
 	return `${grade.stg}-${grade.kztn}-${grade.pon}`
@@ -95,7 +94,7 @@ export default function GradesSCreen(): React.JSX.Element {
 	}
 
 	const { data: spoWeights, isLoading: isSpoLoading } = useQuery({
-		queryKey: ['spoWeights', packageInfo.version],
+		queryKey: ['spoWeights', appVersion],
 		queryFn: async () => await NeulandAPI.getSpoWeights(),
 		staleTime: 1000 * 60 * 60 * 24 * 7,
 		gcTime: 1000 * 60 * 60 * 24 * 14

--- a/src/data/app-version.ts
+++ b/src/data/app-version.ts
@@ -1,0 +1,4 @@
+import packageInfo from '../../package.json'
+
+export const appHomepage = packageInfo.homepage
+export const appVersion = packageInfo.version

--- a/src/hooks/useMapQueries.ts
+++ b/src/hooks/useMapQueries.ts
@@ -11,6 +11,7 @@ import {
 } from '@/api/thi-session-handler'
 import { UserKindContext } from '@/components/contexts'
 import { MapContext } from '@/contexts/map'
+import { appVersion } from '@/data/app-version'
 import { USER_GUEST } from '@/data/constants'
 import { type FeatureProperties, Gebaeude } from '@/types/asset-api'
 import { SEARCH_TYPES } from '@/types/map'
@@ -29,7 +30,6 @@ import {
 	getRoomOpenings
 } from '@/utils/map-utils'
 import { loadTimetable } from '@/utils/timetable-utils'
-import packageInfo from '../../package.json'
 
 export function useMapQueries(): {
 	mapOverlay: FeatureCollection | undefined
@@ -46,7 +46,7 @@ export function useMapQueries(): {
 
 	const { data: mapOverlay, error: overlayError } = useQuery<FeatureCollection>(
 		{
-			queryKey: ['mapOverlay', packageInfo.version],
+			queryKey: ['mapOverlay', appVersion],
 			queryFn: async () => await NeulandAPI.getMapOverlay(),
 			staleTime: 1000 * 60 * 60 * 24 * 7, // 1 week
 			gcTime: 1000 * 60 * 60 * 24 * 60, // 60 days


### PR DESCRIPTION
## Description

Moves package metadata imports into one module so app code no longer imports `package.json` directly.

Closes #371.

## Checklist

- [ ] I've tested my changes on iOS
- [ ] I've tested my changes on Android
- [ ] I've tested my changes on Web
- [ ] I've added or updated documentation (if needed)
- [x] I've reviewed the related issues, if any

## Additional Notes

`bun lint`, `bun tsc --noEmit`, and `bun i18n:check` pass.
