### PR TITLE
fix: remove inefficient allergen banner shadow

### DIFF
--- a/src/components/Food/allergens-banner.tsx
+++ b/src/components/Food/allergens-banner.tsx
@@ -37,11 +37,7 @@ export const AllergensBanner = ({
 				className="rounded-md mb-2.5 mt-0.5 p-2.5 border"
 				style={{
 					backgroundColor: `${primary}33`,
-					borderColor: `${primary}20`,
-					shadowColor: primary,
-					shadowOffset: { width: 0, height: 1 },
-					shadowOpacity: 0.1,
-					shadowRadius: 2
+					borderColor: `${primary}20`
 				}}
 			>
 				<TouchableOpacity


### PR DESCRIPTION
## Problem
The translucent allergen banner used a native shadow that iOS could not calculate efficiently.

## Fix
Removed the decorative shadow from the translucent banner.

## Verification
- `bun tsc --noEmit`
- `bun lint`
- Confirmed the warning no longer appears in simulator logs.