### PR TITLE
feat: add testIDs to prepare for e2e tests

### DIFF
--- a/src/app/(screens)/about.tsx
+++ b/src/app/(screens)/about.tsx
@@ -131,6 +131,7 @@ export default function About(): React.JSX.Element {
 		header: t('about.formlist.app.title'),
 		items: [
 			{
+				testID: 'about-version-link',
 				title: t('about.formlist.app.version'),
 				icon: {
 					ios: 'info.circle',
@@ -144,6 +145,7 @@ export default function About(): React.JSX.Element {
 				}
 			},
 			{
+				testID: 'about-changelog-link',
 				title: t('about.formlist.app.changelog'),
 				icon: {
 					ios: 'list.bullet.rectangle',
@@ -223,6 +225,7 @@ export default function About(): React.JSX.Element {
 			header: t('about.formlist.legal.title'),
 			items: [
 				{
+					testID: 'about-legal-link',
 					title: t('about.formlist.legal.button'),
 					icon: {
 						ios: 'hand.raised',
@@ -276,6 +279,7 @@ export default function About(): React.JSX.Element {
 
 	return (
 		<ScrollView
+			testID="about-screen"
 			contentContainerClassName="pb-bottom-safe"
 			style={{ paddingTop: headerPadding }}
 		>
@@ -371,6 +375,7 @@ export default function About(): React.JSX.Element {
 				}}
 			>
 				<SingleSectionPicker
+					testID="analytics-consent-toggle"
 					title={t('about.analytics.toggle')}
 					selectedItem={analyticsAllowed === true}
 					action={setAnalyticsAllowed}

--- a/src/app/(screens)/app-icon.ios.tsx
+++ b/src/app/(screens)/app-icon.ios.tsx
@@ -63,6 +63,7 @@ export default function AppIconPicker(): React.JSX.Element {
 	}
 	return (
 		<ScrollView
+			testID="app-icon-screen"
 			contentContainerClassName="self-center pb-[50px] w-full"
 			contentInsetAdjustmentBehavior="automatic"
 			showsVerticalScrollIndicator={false}
@@ -78,6 +79,12 @@ export default function AppIconPicker(): React.JSX.Element {
 						return (
 							<React.Fragment key={icon}>
 								<Pressable
+									testID={`app-icon-${icon}`}
+									accessibilityRole="radio"
+									accessibilityState={{
+										selected: unlocked && currentIcon === icon,
+										disabled: !unlocked
+									}}
 									className="items-center flex-row justify-between pe-5 ps-3 py-3"
 									onPress={
 										unlocked
@@ -143,6 +150,9 @@ export default function AppIconPicker(): React.JSX.Element {
 						appIconCategories.neuland.map((icon, index) => (
 							<React.Fragment key={icon}>
 								<Pressable
+									testID={`app-icon-${icon}`}
+									accessibilityRole="radio"
+									accessibilityState={{ selected: currentIcon === icon }}
 									className="items-center flex-row justify-between pe-5 ps-3 py-3"
 									onPress={async () => {
 										try {
@@ -219,6 +229,9 @@ export default function AppIconPicker(): React.JSX.Element {
 						{appIconCategories[key].map((icon, index) => (
 							<React.Fragment key={icon}>
 								<Pressable
+									testID={`app-icon-${icon}`}
+									accessibilityRole="radio"
+									accessibilityState={{ selected: currentIcon === icon }}
 									className="items-center flex-row justify-between pe-5 ps-3 py-3"
 									onPress={async () => {
 										try {

--- a/src/app/(screens)/calendar.tsx
+++ b/src/app/(screens)/calendar.tsx
@@ -92,16 +92,22 @@ export default function CalendarPage(): React.JSX.Element {
 	}, [shouldOpenExam])
 
 	return (
-		<View className="flex-1" style={{ paddingTop: headerPadding }}>
+		<View
+			testID="calendar-screen"
+			className="flex-1"
+			style={{ paddingTop: headerPadding }}
+		>
 			<View className="border-border pb-3.5 px-page">
 				<ToggleRow
 					items={displayTypes}
 					selectedElement={selectedData}
 					setSelectedElement={setPage}
+					testID="calendar-page"
 				/>
 			</View>
 
 			<PagerView
+				testID="calendar-pager"
 				ref={pagerViewRef}
 				style={{
 					flex: 1,

--- a/src/app/(screens)/dashboard.tsx
+++ b/src/app/(screens)/dashboard.tsx
@@ -131,6 +131,7 @@ export default function DashboardEdit(): React.JSX.Element {
 							) : (
 								<View className="rounded-md flex-1 overflow-hidden">
 									<DraggableFlatList
+										testID="dashboard-order-list"
 										data={transShownDashboardEntries}
 										onDragBegin={() => {
 											if (Platform.OS === 'ios') {

--- a/src/app/(screens)/events/cl/[id].tsx
+++ b/src/app/(screens)/events/cl/[id].tsx
@@ -357,6 +357,7 @@ export default function ClEventDetail(): React.JSX.Element {
 
 	return (
 		<Animated.ScrollView
+			testID="campus-life-event-detail-screen"
 			className="px-page"
 			contentContainerClassName="gap-3 pb-modal-bottom"
 			onScroll={scrollHandler}

--- a/src/app/(screens)/events/sports/[id].tsx
+++ b/src/app/(screens)/events/sports/[id].tsx
@@ -247,6 +247,7 @@ export default function SportsEventDetail(): React.JSX.Element {
 	const title = sportsEvent?.title[i18n.language as LanguageKey] ?? ''
 	return (
 		<Animated.ScrollView
+			testID="sports-event-detail-screen"
 			className="px-page"
 			contentContainerClassName="gap-3 pb-bottom-safe"
 			onScroll={scrollHandler}

--- a/src/app/(screens)/food-preferences.tsx
+++ b/src/app/(screens)/food-preferences.tsx
@@ -101,12 +101,14 @@ export default function FoodPreferences(): React.JSX.Element {
 			header: t('preferences.sections.labels'),
 			items: [
 				{
+					testID: 'food-allergens-link',
 					title: t('preferences.formlist.allergens'),
 					onPress: () => {
 						router.navigate('/food-allergens')
 					}
 				},
 				{
+					testID: 'food-flags-link',
 					title: t('preferences.formlist.flags'),
 					onPress: () => {
 						router.navigate('/food-flags')

--- a/src/app/(screens)/food/[id].tsx
+++ b/src/app/(screens)/food/[id].tsx
@@ -167,6 +167,7 @@ export default function FoodDetail(): React.JSX.Element {
 
 	return (
 		<Animated.ScrollView
+			testID="food-detail-screen"
 			contentContainerClassName="mx-page pb-bottom-safe"
 			onScroll={scrollHandler}
 			scrollEventThrottle={16}

--- a/src/app/(screens)/grades.tsx
+++ b/src/app/(screens)/grades.tsx
@@ -178,6 +178,7 @@ export default function GradesSCreen(): React.JSX.Element {
 
 	return (
 		<ScrollView
+			testID="grades-screen"
 			contentContainerClassName="pb-8"
 			contentInsetAdjustmentBehavior="automatic"
 			refreshControl={

--- a/src/app/(screens)/lecture.tsx
+++ b/src/app/(screens)/lecture.tsx
@@ -168,6 +168,7 @@ export default function TimetableDetails(): React.JSX.Element {
 
 	return (
 		<Animated.ScrollView
+			testID="lecture-details-screen"
 			ref={ref}
 			contentContainerClassName="flex pb-bottom-safe px-page pt-page"
 		>

--- a/src/app/(screens)/lecturers.tsx
+++ b/src/app/(screens)/lecturers.tsx
@@ -76,7 +76,11 @@ export default function LecturersScreen(): React.JSX.Element {
 
 	return (
 		<SafeAreaProvider>
-			<SafeAreaView style={styles.page} edges={['top']}>
+			<SafeAreaView
+				testID="lecturers-screen"
+				style={styles.page}
+				edges={['top']}
+			>
 				{userKind === USER_GUEST ? (
 					<ErrorView title={guestError} />
 				) : !isSearchBarFocused ? (

--- a/src/app/(screens)/legal.tsx
+++ b/src/app/(screens)/legal.tsx
@@ -37,6 +37,7 @@ export default function About(): React.JSX.Element {
 						(await Linking.openURL(IMPRINT_URL)) as Promise<void>
 				},
 				{
+					testID: 'legal-licenses-link',
 					title: t('navigation.licenses.title', { ns: 'navigation' }),
 					icon: {
 						ios: 'shield',
@@ -94,6 +95,7 @@ export default function About(): React.JSX.Element {
 
 	return (
 		<ScrollView
+			testID="legal-screen"
 			contentContainerClassName="pb-bottom-safe"
 			style={{ paddingTop: headerPadding }}
 		>

--- a/src/app/(screens)/library.tsx
+++ b/src/app/(screens)/library.tsx
@@ -139,6 +139,7 @@ export default function LibraryCode(): React.JSX.Element {
 				<>
 					<FormList sections={sections} />
 					<Pressable
+						testID="library-barcode"
 						className="self-center rounded-mg mt-5 px-2.5 py-3.5 w-full"
 						style={{ backgroundColor: staticColors.white }}
 						onPress={() => {

--- a/src/app/(screens)/licenses.tsx
+++ b/src/app/(screens)/licenses.tsx
@@ -101,6 +101,7 @@ export default function Licenses(): React.JSX.Element {
 	]
 	return (
 		<ScrollView
+			testID="licenses-screen"
 			contentContainerClassName="pb-modal-bottom"
 			contentInsetAdjustmentBehavior="automatic"
 		>

--- a/src/app/(screens)/links.tsx
+++ b/src/app/(screens)/links.tsx
@@ -53,7 +53,10 @@ const LinkScreen = (): React.JSX.Element => {
 	const sections = generateSections(typedQuicklinks)
 
 	return (
-		<View className="ios:mt-0 android:mt-3.5 web:mt-3 px-page">
+		<View
+			testID="quick-links-screen"
+			className="ios:mt-0 android:mt-3.5 web:mt-3 px-page"
+		>
 			<FormList sections={sections} sheet />
 		</View>
 	)

--- a/src/app/(screens)/news.tsx
+++ b/src/app/(screens)/news.tsx
@@ -38,7 +38,7 @@ export default function NewsScreen(): React.JSX.Element {
 	const { isRefetchingByUser, refetchByUser } = useRefreshByUser(refetch)
 
 	return (
-		<View className="flex-1 web:h-full">
+		<View testID="news-screen" className="flex-1 web:h-full">
 			{isLoading ? (
 				<View className="items-center justify-center ios:pt-[140px] android:pt-10">
 					<LoadingIndicator />

--- a/src/app/(screens)/onboarding.tsx
+++ b/src/app/(screens)/onboarding.tsx
@@ -53,6 +53,7 @@ function OnboardingContinueButton({
 }: OnboardingContinueButtonProps): React.JSX.Element {
 	return (
 		<Pressable
+			testID="onboarding-continue"
 			className="self-center bg-primary rounded-md px-6 py-3.5 w-1/2"
 			onPress={onContinue}
 			disabled={disabled}

--- a/src/app/(screens)/profile.tsx
+++ b/src/app/(screens)/profile.tsx
@@ -235,6 +235,7 @@ export default function Profile(): React.JSX.Element {
 
 	return (
 		<ScrollView
+			testID="profile-screen"
 			contentContainerClassName="pb-8"
 			contentInsetAdjustmentBehavior="automatic"
 			showsVerticalScrollIndicator={false}
@@ -295,6 +296,7 @@ export default function Profile(): React.JSX.Element {
 				))}
 
 			<Pressable
+				testID="profile-logout"
 				onPress={logoutAlert}
 				className="items-center self-center bg-card rounded-mg border-border flex-row gap-2.5 justify-center mb-[30px] mt-2.5 min-w-copy-button-min px-10 py-3"
 				style={hairlineBorder}

--- a/src/app/(screens)/room-report.tsx
+++ b/src/app/(screens)/room-report.tsx
@@ -96,7 +96,10 @@ export default function RoomReport(): React.JSX.Element {
 		: primaryColor
 
 	return (
-		<ScrollView contentContainerClassName="bg-background p-page">
+		<ScrollView
+			testID="room-report-screen"
+			contentContainerClassName="bg-background p-page"
+		>
 			<View className="justify-center pb-5 pt-2.5">
 				<View className="flex-row justify-between pb-2.5">
 					<Text className="text-text text-[23px] font-semibold mb-3.5">
@@ -108,6 +111,7 @@ export default function RoomReport(): React.JSX.Element {
 					{t('pages.rooms.report.room.title')}
 				</Text>
 				<TextInput
+					testID="room-report-room"
 					className="bg-input-background rounded-mg text-text flex-1 text-[17px] h-10 mb-2.5 px-2.5 border"
 					style={{ borderColor, backgroundColor: inputBackground }}
 					value={roomTitle}
@@ -119,6 +123,7 @@ export default function RoomReport(): React.JSX.Element {
 					{t('pages.rooms.report.category.title')}
 				</Text>
 				<CustomDropdown
+					testID="room-report-category"
 					value={reportCategory}
 					onChange={setReportCategory}
 					options={reportCategories.map((category) => ({
@@ -141,6 +146,7 @@ export default function RoomReport(): React.JSX.Element {
 					{t('pages.rooms.report.description.title')}
 				</Text>
 				<TextInput
+					testID="room-report-description"
 					editable
 					multiline
 					numberOfLines={4}
@@ -157,6 +163,7 @@ export default function RoomReport(): React.JSX.Element {
 				/>
 
 				<Pressable
+					testID="room-report-submit"
 					disabled={submitDisabled}
 					onPress={() => {
 						if (!reportCategory || !description || !room) return

--- a/src/app/(screens)/room-search.ios.tsx
+++ b/src/app/(screens)/room-search.ios.tsx
@@ -30,7 +30,11 @@ export default function AdvancedSearch(): React.JSX.Element {
 	const duration = usePickerBinding(roomSearch.duration, roomSearch.setDuration)
 
 	return (
-		<ScrollView className="p-3" style={{ paddingTop: headerPadding }}>
+		<ScrollView
+			testID="room-search-screen"
+			className="p-3"
+			style={{ paddingTop: headerPadding }}
+		>
 			<View>
 				<Text className="text-label-secondary text-[13px] font-normal mb-1 uppercase">
 					{t('pages.rooms.options.title')}
@@ -42,6 +46,7 @@ export default function AdvancedSearch(): React.JSX.Element {
 						</Text>
 
 						<DateTimePicker
+							testID="room-search-date"
 							value={roomSearch.searchDateTime}
 							mode="date"
 							accentColor={primaryColor}
@@ -61,6 +66,7 @@ export default function AdvancedSearch(): React.JSX.Element {
 						</Text>
 
 						<DateTimePicker
+							testID="room-search-time"
 							value={roomSearch.searchDateTime}
 							mode="time"
 							is24Hour={true}
@@ -73,7 +79,10 @@ export default function AdvancedSearch(): React.JSX.Element {
 						/>
 					</View>
 					<Divider paddingLeft={16} />
-					<View className="items-center flex-row justify-between px-[15px] py-2">
+					<View
+						testID="room-search-duration"
+						className="items-center flex-row justify-between px-[15px] py-2"
+					>
 						<Text className="text-text text-[15px]">
 							{t('pages.rooms.options.duration')}
 						</Text>
@@ -90,7 +99,10 @@ export default function AdvancedSearch(): React.JSX.Element {
 						</Picker>
 					</View>
 					<Divider paddingLeft={16} />
-					<View className="items-center flex-row justify-between px-[15px] py-2">
+					<View
+						testID="room-search-building"
+						className="items-center flex-row justify-between px-[15px] py-2"
+					>
 						<Text className="text-text text-[15px]">
 							{t('pages.rooms.options.building')}
 						</Text>

--- a/src/app/(screens)/room-search.tsx
+++ b/src/app/(screens)/room-search.tsx
@@ -79,7 +79,7 @@ export default function AdvancedSearch(): React.JSX.Element {
 	}
 
 	return (
-		<ScrollView className="p-3">
+		<ScrollView testID="room-search-screen" className="p-3">
 			<View>
 				<Text className="text-label-secondary text-[13px] font-normal mb-1 uppercase">
 					{t('pages.rooms.options.title')}
@@ -110,6 +110,7 @@ export default function AdvancedSearch(): React.JSX.Element {
 						) : (
 							showDate && (
 								<DateTimePicker
+									testID="room-search-date"
 									value={roomSearch.searchDateTime}
 									mode="date"
 									accentColor={primaryColor}
@@ -149,6 +150,7 @@ export default function AdvancedSearch(): React.JSX.Element {
 						) : (
 							showTime && (
 								<DateTimePicker
+									testID="room-search-time"
 									value={roomSearch.searchDateTime}
 									mode="time"
 									is24Hour={true}

--- a/src/app/(screens)/sports.tsx
+++ b/src/app/(screens)/sports.tsx
@@ -43,7 +43,11 @@ export default function SportsScreen(): React.JSX.Element {
 	)
 
 	return (
-		<View className="flex-1" style={{ paddingTop: headerPadding + 12 }}>
+		<View
+			testID="sports-screen"
+			className="flex-1"
+			style={{ paddingTop: headerPadding + 12 }}
+		>
 			<ClSportsPage sportsResult={sportsResult} />
 		</View>
 	)

--- a/src/app/(screens)/theme.tsx
+++ b/src/app/(screens)/theme.tsx
@@ -57,6 +57,7 @@ export default function Theme(): React.JSX.Element {
 
 	return (
 		<ScrollView
+			testID="theme-screen"
 			className="flex-1 bg-background"
 			style={{ paddingTop: headerPadding }}
 		>

--- a/src/app/(screens)/timetable-preferences.tsx
+++ b/src/app/(screens)/timetable-preferences.tsx
@@ -82,6 +82,7 @@ export default function TimetablePreferences(): React.JSX.Element {
 
 	return (
 		<ScrollView
+			testID="timetable-preferences-screen"
 			style={{
 				paddingBottom: insets.bottom + 32
 			}}
@@ -91,6 +92,7 @@ export default function TimetablePreferences(): React.JSX.Element {
 			<View className="flex-1">
 				<SectionView title={t('timetable:preferences.title')}>
 					<SingleSectionPicker
+						testID="timetable-list-mode"
 						title={t('timetable:viewModes.list')}
 						selectedItem={timetableMode === TimetableMode.List}
 						action={toggleListMode}

--- a/src/app/(screens)/version.tsx
+++ b/src/app/(screens)/version.tsx
@@ -238,11 +238,13 @@ export default function Version(): React.JSX.Element {
 
 	return (
 		<ScrollView
+			testID="version-screen"
 			contentContainerClassName="p-page pb-bottom-safe"
 			contentInsetAdjustmentBehavior="automatic"
 		>
 			<FormList sections={sections} />
 			<Pressable
+				testID="version-copy-all"
 				className="items-center self-center bg-card rounded-mg border-border flex-row gap-2.5 justify-center my-section min-w-copy-button-min px-10 py-3"
 				style={hairlineBorder}
 				onPress={handleCopyAll}

--- a/src/app/(screens)/webview.tsx
+++ b/src/app/(screens)/webview.tsx
@@ -132,7 +132,10 @@ export default function NotesDetails(): React.JSX.Element {
 			.trim()
 
 		return (
-			<ScrollView contentContainerClassName="p-4 pb-[80px] bg-background">
+			<ScrollView
+				testID="lecture-webview-screen"
+				contentContainerClassName="p-4 pb-[80px] bg-background"
+			>
 				<Text className="text-text text-base leading-6">
 					{plainTextContent}
 				</Text>
@@ -141,7 +144,7 @@ export default function NotesDetails(): React.JSX.Element {
 	}
 
 	return (
-		<View className="flex-1 bg-background">
+		<View testID="lecture-webview-screen" className="flex-1 bg-background">
 			<WebView
 				source={{ html: styledHtml }}
 				scalesPageToFit

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -164,6 +164,7 @@ const HomeScreen = memo(function HomeScreen() {
 		</View>
 	) : columns === 1 ? (
 		<FlashList
+			testID="home-screen"
 			estimatedItemSize={130}
 			key={orientation}
 			contentInsetAdjustmentBehavior="automatic"
@@ -177,6 +178,7 @@ const HomeScreen = memo(function HomeScreen() {
 		/>
 	) : (
 		<MasonryFlashList
+			testID="home-screen"
 			key={orientation}
 			contentInsetAdjustmentBehavior="automatic"
 			contentInset={{ top: 0, bottom: 90 }}

--- a/src/components/Cards/base-card.tsx
+++ b/src/components/Cards/base-card.tsx
@@ -21,6 +21,7 @@ import { CardContextMenu } from './card-context-menu'
 
 interface BaseCardProps {
 	title: string
+	testID?: string
 	onPressRoute?: Href
 	children?: React.ReactNode
 	noDataComponent?: React.ReactNode
@@ -29,6 +30,7 @@ interface BaseCardProps {
 
 const BaseCard = ({
 	title,
+	testID,
 	onPressRoute,
 	children,
 	noDataComponent,
@@ -129,6 +131,7 @@ const BaseCard = ({
 			<CardContextMenu
 				card={
 					<Pressable
+						testID={testID ?? `dashboard-card-${title}`}
 						disabled={onPressRoute == null}
 						onPress={() => {
 							if (onPressRoute != null) {
@@ -156,6 +159,7 @@ const BaseCard = ({
 			disabled={onPressRoute == null}
 		>
 			<Pressable
+				testID={testID ?? `dashboard-card-${title}`}
 				onPressIn={handlePressIn}
 				onPressOut={handlePressOut}
 				className="w-full"

--- a/src/components/Dashboard/orderable-row-item.tsx
+++ b/src/components/Dashboard/orderable-row-item.tsx
@@ -41,6 +41,7 @@ export default function OrderableRowItem({
 	return (
 		<View>
 			<Pressable
+				testID={`dashboard-order-item-${item.key}`}
 				onLongPress={drag}
 				className="items-center bg-card flex-row gap-3.5 justify-center min-h-[50px] px-4"
 				style={{

--- a/src/components/Events/campus-life-events-screen.tsx
+++ b/src/components/Events/campus-life-events-screen.tsx
@@ -108,7 +108,11 @@ export default function CampusLifeEventsScreen({
 	}
 
 	return (
-		<View className="flex-1" style={{ paddingTop: headerPadding + 12 }}>
+		<View
+			testID="campus-life-events-screen"
+			className="flex-1"
+			style={{ paddingTop: headerPadding + 12 }}
+		>
 			{enableSportsTabRedirect && tab === 'sports' ? (
 				<View className="flex-1 justify-center items-center">
 					<LoadingIndicator />

--- a/src/components/Flow/login.tsx
+++ b/src/components/Flow/login.tsx
@@ -66,6 +66,7 @@ export default function Login(): React.JSX.Element {
 		<TouchableWithoutFeedback
 			onPress={Keyboard.dismiss}
 			disabled={Platform.OS === 'web'}
+			accessible={false}
 		>
 			<View
 				className="self-center flex-1 w-[90%]"

--- a/src/components/Food/auto-show-next-day-setting.tsx
+++ b/src/components/Food/auto-show-next-day-setting.tsx
@@ -77,6 +77,7 @@ export default function AutoShowNextDaySetting({
 	return (
 		<View>
 			<SingleSectionPicker
+				testID="food-auto-next-day-toggle"
 				title={title}
 				selectedItem={enabled}
 				action={onToggle}
@@ -111,6 +112,7 @@ export default function AutoShowNextDaySetting({
 						<View className="flex-row items-center justify-between py-1">
 							<Text className="text-text text-base">{timeLabel}</Text>
 							<DateTimePicker
+								testID="food-auto-next-day-time"
 								mode={'time'}
 								display={'compact'}
 								value={time}
@@ -120,6 +122,7 @@ export default function AutoShowNextDaySetting({
 					) : (
 						<>
 							<Pressable
+								testID="food-auto-next-day-time"
 								onPress={() => {
 									setShowAndroidTimePicker(true)
 								}}
@@ -135,6 +138,7 @@ export default function AutoShowNextDaySetting({
 							</Pressable>
 							{showAndroidTimePicker && (
 								<DateTimePicker
+									testID="food-auto-next-day-time-picker"
 									mode={'time'}
 									value={time}
 									onChange={handleSetTime}

--- a/src/components/Food/food-day-button.tsx
+++ b/src/components/Food/food-day-button.tsx
@@ -43,7 +43,12 @@ export const FoodDayButton = memo(
 					isLastDay ? { marginRight: 0 } : undefined
 				]}
 			>
-				<Pressable onPress={handlePress}>
+				<Pressable
+					testID={`food-day-${index}`}
+					accessibilityRole="button"
+					accessibilityState={{ selected: isSelected }}
+					onPress={handlePress}
+				>
 					<View
 						className="items-center self-center bg-card rounded-md border-border h-[60px] justify-evenly py-2 w-full"
 						style={hairlineBorder}

--- a/src/components/Food/food-language-section.tsx
+++ b/src/components/Food/food-language-section.tsx
@@ -30,6 +30,9 @@ const MultiSectionRadio = ({
 				<React.Fragment key={index}>
 					<View className="h-[52px]">
 						<Pressable
+							testID={`radio-option-${item.key}`}
+							accessibilityRole="radio"
+							accessibilityState={{ selected: selectedItem === item.key }}
 							onPress={() => {
 								if (Platform.OS === 'ios') {
 									void selectionAsync()

--- a/src/components/Food/food-screen.tsx
+++ b/src/components/Food/food-screen.tsx
@@ -153,7 +153,7 @@ function FoodScreen(): React.JSX.Element {
 
 	return (
 		<SafeAreaProvider>
-			<SafeAreaView style={styles.page} edges={['top']}>
+			<SafeAreaView testID="food-screen" style={styles.page} edges={['top']}>
 				{isLoading && !isRefetchingByUser ? (
 					<View style={styles.loadingContainer}>
 						<FoodLoadingIndicator size={140} />
@@ -205,6 +205,7 @@ function FoodScreen(): React.JSX.Element {
 						</Animated.View>
 						{showAllergensBanner && <AllergensBanner scrollY={scrollY} />}
 						<PagerView
+							testID="food-pager"
 							ref={pagerViewRef}
 							style={styles.page}
 							initialPage={initialPageRef.current}

--- a/src/components/Food/items-picker-screen.tsx
+++ b/src/components/Food/items-picker-screen.tsx
@@ -109,6 +109,9 @@ const ItemsPickerScreen = ({
 		return (
 			<View className="mb-2 h-[52px]">
 				<Pressable
+					testID={`${type}-option-${item.key}`}
+					accessibilityRole="checkbox"
+					accessibilityState={{ checked: isSelected }}
 					className="bg-card rounded-2xl p-4 flex-row items-center justify-between h-full"
 					onPress={toggleItem}
 				>
@@ -138,6 +141,7 @@ const ItemsPickerScreen = ({
 	if (filteredEntries.length > 0) {
 		return (
 			<FlashList
+				testID={`${type}-picker`}
 				data={filteredEntries}
 				renderItem={renderItem}
 				estimatedItemSize={60}

--- a/src/components/Food/meal-entry.tsx
+++ b/src/components/Food/meal-entry.tsx
@@ -92,6 +92,7 @@ export const MealEntry = memo(({ meal }: { meal: Meal }): React.JSX.Element => {
 	const cardContent = (
 		<Link asChild href={`/food/${meal.id}`}>
 			<Pressable
+				testID="food-meal-entry"
 				delayLongPress={300}
 				onLongPress={() => {
 					/* nothing */

--- a/src/components/Map/attribution-link.tsx
+++ b/src/components/Map/attribution-link.tsx
@@ -12,6 +12,7 @@ const AttributionLink = (): React.JSX.Element => {
 	return (
 		<View className="py-10">
 			<Pressable
+				testID="map-attribution"
 				onPress={() => {
 					void Linking.openURL('https://www.openstreetmap.org/copyright')
 				}}

--- a/src/components/Map/available-rooms-suggestions.tsx
+++ b/src/components/Map/available-rooms-suggestions.tsx
@@ -38,7 +38,7 @@ const AvailableRoomsSuggestions = ({
 	const { setClickedElement, availableRooms, setCurrentFloor } = use(MapContext)
 
 	return (
-		<View>
+		<View testID="map-available-rooms">
 			<View className="items-end flex-row justify-between mb-1">
 				<Text className="text-text text-label-secondary ios:text-base ios:font-semibold android:text-[13px] android:font-normal android:uppercase web:text-base web:font-semibold mb-0.5 pt-2 text-left">
 					{t('pages.map.details.room.availableRooms')}
@@ -123,6 +123,7 @@ const AvailableRoomsSuggestions = ({
 						return roomSuggestions.map((room, key) => (
 							<React.Fragment key={key}>
 								<Pressable
+									testID="map-available-room-row"
 									className="flex-row px-3 py-[18px]"
 									onPress={() => {
 										const details = allRooms.features.find(

--- a/src/components/Map/bottom-sheet-detail-modal.tsx
+++ b/src/components/Map/bottom-sheet-detail-modal.tsx
@@ -47,6 +47,7 @@ const ReportLink = ({ roomTitle }: ReportLinkProps): React.JSX.Element => {
 	return (
 		<View className="py-2.5">
 			<Pressable
+				testID="map-room-report"
 				onPress={() => handleReportRoom()}
 				className="items-center flex-row gap-1"
 			>
@@ -102,7 +103,10 @@ export const BottomSheetDetailModal = ({
 				animatedPosition={currentPositionModal}
 				handleIndicatorStyle={{ backgroundColor: labelTertiaryColor }}
 			>
-				<StyledBottomSheetView className="flex-1 px-page">
+				<StyledBottomSheetView
+					testID="map-room-detail"
+					className="flex-1 px-page"
+				>
 					<View className="flex-row justify-between pb-0">
 						<Text className="text-text text-[26px] font-semibold text-left">
 							{roomData.title}
@@ -110,6 +114,7 @@ export const BottomSheetDetailModal = ({
 						<View className="flex-row gap-2.5 mb-[3px]">
 							{roomData.type === SEARCH_TYPES.ROOM && (
 								<Pressable
+									testID="map-room-share"
 									onPress={() => {
 										if (Platform.OS === 'web') {
 											setCopied(true)
@@ -142,6 +147,7 @@ export const BottomSheetDetailModal = ({
 								</Pressable>
 							)}
 							<Pressable
+								testID="map-room-detail-close"
 								onPress={() => {
 									bottomSheetModalRef.current?.close()
 								}}

--- a/src/components/Map/bottom-sheet-map.tsx
+++ b/src/components/Map/bottom-sheet-map.tsx
@@ -88,6 +88,7 @@ const MapBottomSheet = ({
 	return (
 		<StyledBottomSheet
 			ref={bottomSheetRef}
+			accessible={false}
 			index={1}
 			snapPoints={Platform.OS === 'ios' ? IOS_SNAP_POINTS : DEFAULT_SNAP_POINTS}
 			backgroundComponent={BottomSheetBackground}
@@ -107,6 +108,7 @@ const MapBottomSheet = ({
 			<View className="px-page">
 				<View className="flex-row h-10 mb-2.5">
 					<TextInput
+						testID="map-search-input"
 						ref={textInputRef}
 						className="rounded-mg flex-1 text-[17px] h-10 mb-2.5 px-2.5"
 						style={{
@@ -146,6 +148,7 @@ const MapBottomSheet = ({
 
 					<Animated.View className="justify-center" style={animatedCancelStyle}>
 						<Pressable
+							testID="map-search-cancel"
 							onPress={() => {
 								setLocalSearch('')
 								textInputRef.current?.blur()

--- a/src/components/Map/floor-picker.tsx
+++ b/src/components/Map/floor-picker.tsx
@@ -41,6 +41,7 @@ const FloorPicker = ({
 		<View className="mx-2 mt-[110px] absolute right-0">
 			{!showAllFloors && (
 				<Pressable
+					testID="map-floor-picker"
 					onPress={() => {
 						toggleShowAllFloors()
 					}}
@@ -76,6 +77,7 @@ const FloorPicker = ({
 			)}
 			{showAllFloors && (
 				<Pressable
+					testID="map-floor-picker-close"
 					onPress={() => {
 						toggleShowAllFloors()
 					}}
@@ -108,6 +110,7 @@ const FloorPicker = ({
 						const isLast = index === floors.length - 1
 						return (
 							<Pressable
+								testID={`map-floor-${floor}`}
 								onPress={() => {
 									if (Platform.OS === 'ios') {
 										void Haptics.selectionAsync()
@@ -140,6 +143,7 @@ const FloorPicker = ({
 			)}
 			{Platform.OS !== 'web' && (
 				<Pressable
+					testID="map-current-location"
 					onPress={() => {
 						setCameraTriggerKey((prev) => prev + 1)
 					}}

--- a/src/components/Map/map-screen.tsx
+++ b/src/components/Map/map-screen.tsx
@@ -399,7 +399,7 @@ const MapScreen = (): React.JSX.Element => {
 	}, [])
 
 	return (
-		<View className="flex-1">
+		<View testID="map-screen" className="flex-1">
 			{mapLoadState === LoadingState.ERROR && (
 				<View
 					className="flex-1 h-full justify-center absolute w-full z-[100]"
@@ -420,7 +420,7 @@ const MapScreen = (): React.JSX.Element => {
 				</View>
 			)}
 
-			<View className="flex-1" style={{ marginBottom: 0 }}>
+			<View testID="map-canvas" className="flex-1" style={{ marginBottom: 0 }}>
 				<MapView
 					key={mapKey}
 					style={{ flex: 1 }}

--- a/src/components/Map/map-screen.web.tsx
+++ b/src/components/Map/map-screen.web.tsx
@@ -455,7 +455,7 @@ const MapScreen = (): React.JSX.Element => {
 	)
 
 	return (
-		<View className="flex-1">
+		<View testID="map-screen" className="flex-1">
 			{mapLoadState === LoadingState.ERROR && (
 				<View
 					className="flex-1 h-full justify-center absolute w-full z-[100]"
@@ -472,7 +472,7 @@ const MapScreen = (): React.JSX.Element => {
 					<LoadingIndicator />
 				</View>
 			)}
-			<div style={mapContainerStyle}>
+			<div data-testid="map-canvas" style={mapContainerStyle}>
 				<Map
 					mapLib={maplibregl}
 					initialViewState={{

--- a/src/components/Map/next-lecture-suggestion.tsx
+++ b/src/components/Map/next-lecture-suggestion.tsx
@@ -38,7 +38,7 @@ const NextLectureSuggestion = ({
 		return null
 	}
 	return (
-		<View className="mb-2.5">
+		<View testID="map-next-lecture" className="mb-2.5">
 			<View className="items-end flex-row justify-between mb-1">
 				<Text className="text-text text-label-secondary ios:text-base ios:font-semibold android:text-[13px] android:font-normal android:uppercase web:text-base web:font-semibold mb-0.5 pt-2 text-left">
 					{t('pages.map.details.room.nextLecture')}
@@ -57,6 +57,7 @@ const NextLectureSuggestion = ({
 				{nextLecture.map((lecture, key) => (
 					<React.Fragment key={key}>
 						<Pressable
+							testID="map-next-lecture-row"
 							disabled={
 								lecture.rooms.length === 0 || !isValidRoom(lecture.rooms[0])
 							}

--- a/src/components/Map/search-result-row.tsx
+++ b/src/components/Map/search-result-row.tsx
@@ -34,6 +34,7 @@ const ResultRow = ({
 	const roomTypeKey = i18n.language === 'de' ? 'Funktion_de' : 'Funktion_en'
 	return (
 		<StyledBottomSheetTouchableOpacity
+			testID={`map-search-result-${result.title}`}
 			className="items-center flex-row py-2.5"
 			onPress={() => {
 				const center = result.item.properties?.center as Position | undefined

--- a/src/components/Member/logged-in-view.tsx
+++ b/src/components/Member/logged-in-view.tsx
@@ -192,6 +192,7 @@ export function LoggedInView(): React.JSX.Element {
 
 	return (
 		<ScrollView
+			testID="member-screen"
 			contentContainerClassName="px-page pt-5 pb-[30px]"
 			showsVerticalScrollIndicator={false}
 			contentInsetAdjustmentBehavior="automatic"

--- a/src/components/Member/member-area-button.tsx
+++ b/src/components/Member/member-area-button.tsx
@@ -19,6 +19,7 @@ export function MemberAreaButton(): React.JSX.Element | null {
 				{t('about.formlist.neuland')}
 			</Text>
 			<Pressable
+				testID="member-area-entry"
 				onPress={() => {
 					router.navigate('/member')
 				}}

--- a/src/components/Member/security-warning-modal.tsx
+++ b/src/components/Member/security-warning-modal.tsx
@@ -95,6 +95,7 @@ export function SecurityWarningModal({
 
 	return (
 		<Modal
+			testID="wallet-security-modal"
 			visible={visible}
 			transparent
 			animationType="fade"
@@ -165,6 +166,7 @@ export function SecurityWarningModal({
 
 						<View className="items-center mb-[18px]">
 							<Pressable
+								testID="wallet-confirm"
 								onPress={handleConfirm}
 								disabled={isAddingToWallet}
 								className="active:opacity-70"
@@ -191,6 +193,7 @@ export function SecurityWarningModal({
 
 						<View className="items-center">
 							<Pressable
+								testID="wallet-cancel"
 								onPress={handleCancel}
 								className="py-3 px-6 rounded-md items-center justify-center bg-card-button active:opacity-70"
 							>

--- a/src/components/Member/security-warning-modal.tsx
+++ b/src/components/Member/security-warning-modal.tsx
@@ -102,6 +102,7 @@ export function SecurityWarningModal({
 			onRequestClose={handleCancel}
 		>
 			<Pressable
+				accessible={false}
 				className="flex-1 bg-black/70 justify-center items-center p-page"
 				onPress={handleCancel}
 			>
@@ -109,7 +110,7 @@ export function SecurityWarningModal({
 					className="bg-card rounded-lg max-w-[400px] w-full"
 					style={hairlineBorder}
 				>
-					<Pressable onPress={() => {}} className="p-6">
+					<Pressable accessible={false} onPress={() => {}} className="p-6">
 						<View className="items-center mb-4">
 							<PlatformIcon
 								ios={{ name: 'exclamationmark.triangle.fill', size: 32 }}

--- a/src/components/Menu/custom-dropdown.tsx
+++ b/src/components/Menu/custom-dropdown.tsx
@@ -4,6 +4,7 @@ import type { ViewStyle } from 'react-native'
 import { Modal, Pressable, Text, View } from 'react-native'
 
 interface CustomDropdownProps<T> {
+	testID?: string
 	value?: T
 	onChange: (value: T) => void
 	options: Array<{
@@ -15,6 +16,7 @@ interface CustomDropdownProps<T> {
 }
 
 export function CustomDropdown<T>({
+	testID,
 	value,
 	onChange,
 	options,
@@ -28,6 +30,7 @@ export function CustomDropdown<T>({
 	return (
 		<>
 			<Pressable
+				testID={testID}
 				className="bg-input-background rounded-md border-border h-10 justify-center px-2.5"
 				style={[{ borderWidth: 1 }, style]}
 				onPress={() => setIsOpen(true)}
@@ -44,12 +47,14 @@ export function CustomDropdown<T>({
 				onRequestClose={() => setIsOpen(false)}
 			>
 				<Pressable
+					accessible={false}
 					className="flex-1 bg-black/50 justify-center items-center"
 					onPress={() => setIsOpen(false)}
 				>
 					<View className="bg-card rounded-lg p-2.5 w-[80%] max-h-[80%]">
 						{options.map((option) => (
 							<Pressable
+								testID={`${testID ?? 'dropdown'}-option-${String(option.value)}`}
 								key={String(option.value)}
 								className={`py-3 px-4 rounded-md ${
 									option.value === value ? 'bg-primary' : ''

--- a/src/components/Rows/event-row.tsx
+++ b/src/components/Rows/event-row.tsx
@@ -42,6 +42,7 @@ const CLEventRow = ({
 
 	return (
 		<RowEntry
+			testID="campus-life-event-row"
 			backgroundColor={
 				toColor(inSheet ? cardSheetColor : cardColor) as string | undefined
 			}

--- a/src/components/Rows/sports-row.tsx
+++ b/src/components/Rows/sports-row.tsx
@@ -18,6 +18,7 @@ const SportsRow = ({
 
 	return (
 		<RowEntry
+			testID="sports-event-row"
 			title={event.title[i18n.language as LanguageKey] ?? ''}
 			href={`/events/sports/${event.id}` as RelativePathString}
 			leftChildren={

--- a/src/components/Settings/guest-info-section.tsx
+++ b/src/components/Settings/guest-info-section.tsx
@@ -12,6 +12,7 @@ export default function GuestInfoSection(): React.JSX.Element {
 
 	return (
 		<Pressable
+			testID="guest-login-banner"
 			className="bg-card border-border ios:rounded-ios android:rounded-md web:rounded-md p-5 flex-row items-center justify-between gap-4 active:opacity-90"
 			style={hairlineBorder}
 			onPress={() => {

--- a/src/components/Settings/neuland-box.tsx
+++ b/src/components/Settings/neuland-box.tsx
@@ -29,6 +29,7 @@ const NeulandBox = (): React.JSX.Element | null => {
 	return (
 		<View className="mt-2.5">
 			<Pressable
+				testID="member-area-entry"
 				onPress={() => router.navigate('/member')}
 				className="ios:rounded-ios android:rounded-md web:rounded-md overflow-hidden w-full active:opacity-90 border-border"
 			>

--- a/src/components/Settings/settings-menu.tsx
+++ b/src/components/Settings/settings-menu.tsx
@@ -57,6 +57,7 @@ export default function SettingsMenu(): React.JSX.Element {
 			header: t('menu.formlist.preferences.title'),
 			items: [
 				{
+					testID: 'settings-dashboard-link',
 					title: t('menu.formlist.preferences.dashboard'),
 					icon: {
 						ios: 'rectangle.stack',
@@ -68,6 +69,7 @@ export default function SettingsMenu(): React.JSX.Element {
 					}
 				},
 				{
+					testID: 'settings-food-preferences-link',
 					title: t('menu.formlist.preferences.food'),
 					icon: {
 						android: 'restaurant',
@@ -117,6 +119,7 @@ export default function SettingsMenu(): React.JSX.Element {
 			header: t('menu.formlist.appearance.title'),
 			items: [
 				{
+					testID: 'settings-theme-link',
 					title: t('menu.formlist.appearance.theme'),
 					icon: {
 						ios: 'moon.stars',
@@ -130,6 +133,7 @@ export default function SettingsMenu(): React.JSX.Element {
 				...(Platform.OS === 'ios' && DeviceInfo.getDeviceType() !== 'Desktop'
 					? [
 							{
+								testID: 'settings-app-icon-link',
 								title: t('menu.formlist.appearance.appIcon'),
 								icon: {
 									ios: 'star.square.on.square',
@@ -148,6 +152,7 @@ export default function SettingsMenu(): React.JSX.Element {
 			header: t('menu.formlist.legal.title'),
 			items: [
 				{
+					testID: 'settings-about-link',
 					title: t('menu.formlist.legal.about'),
 					icon: {
 						ios: 'info.circle',
@@ -159,6 +164,7 @@ export default function SettingsMenu(): React.JSX.Element {
 					}
 				},
 				{
+					testID: 'settings-share-link',
 					title: t('menu.formlist.legal.share'),
 					icon: {
 						ios: 'square.and.arrow.up',

--- a/src/components/Settings/settings-screen.tsx
+++ b/src/components/Settings/settings-screen.tsx
@@ -137,6 +137,7 @@ export default function Settings(): React.JSX.Element {
 
 	return (
 		<ScrollView
+			testID="settings-screen"
 			refreshControl={
 				isError && userKind === 'student' ? (
 					<RefreshControl

--- a/src/components/Timetable/timetable-list.tsx
+++ b/src/components/Timetable/timetable-list.tsx
@@ -153,9 +153,9 @@ export default function TimetableList({
 		router.navigate('/exam')
 	}
 
-	const renderItem = ({
+	function renderItem({
 		item
-	}: ListRenderItemInfo<FlatListItem>): React.JSX.Element | null => {
+	}: ListRenderItemInfo<FlatListItem>): React.JSX.Element | null {
 		if (item.type === 'header') {
 			return <TimetableSectionHeader title={item.title} today={today} />
 		}

--- a/src/components/Timetable/timetable-screen.tsx
+++ b/src/components/Timetable/timetable-screen.tsx
@@ -81,7 +81,7 @@ function TimetableScreen(): React.JSX.Element {
 			: (['bottom', 'top'] as Edges)
 	return (
 		<SafeAreaProvider>
-			<SafeAreaView style={styles.page} edges={edges}>
+			<SafeAreaView testID="timetable-screen" style={styles.page} edges={edges}>
 				{isLoading ? (
 					<LoadingView />
 				) : isSuccess && timetable !== undefined && timetable.length > 0 ? (

--- a/src/components/Universal/button.tsx
+++ b/src/components/Universal/button.tsx
@@ -14,6 +14,7 @@ import { getContrastColor } from '@/utils/ui-utils'
 import { hairlineBorder, toColor } from '@/utils/uniwind-utils'
 
 interface ButtonProps {
+	testID?: string
 	variant?: 'primary' | 'secondary'
 	disabled?: boolean
 	loading?: boolean
@@ -34,6 +35,7 @@ function resolveActiveTheme(
 }
 
 const Button = ({
+	testID,
 	variant = 'primary',
 	disabled = false,
 	loading = false,
@@ -74,6 +76,7 @@ const Button = ({
 
 	return (
 		<TouchableOpacity
+			testID={testID}
 			disabled={isDisabled}
 			onPress={onPress}
 			className={buttonClassName}

--- a/src/components/Universal/form-list.tsx
+++ b/src/components/Universal/form-list.tsx
@@ -187,6 +187,7 @@ const RenderSectionItems = ({
 				return (
 					<React.Fragment key={index}>
 						<Pressable
+							testID={item.testID}
 							onPress={() => {
 								handlePress(item.onPress)
 							}}

--- a/src/components/Universal/login-form.tsx
+++ b/src/components/Universal/login-form.tsx
@@ -232,6 +232,7 @@ const LoginForm = ({
 							style={{ color: labelColor }}
 						/>
 						<TextInput
+							testID="login-username"
 							style={textInputStyle}
 							selectionColor={primaryColor}
 							placeholderTextColor={labelColor}
@@ -261,6 +262,7 @@ const LoginForm = ({
 							style={{ color: labelColor }}
 						/>
 						<TextInput
+							testID="login-password"
 							style={textInputStyle}
 							selectionColor={primaryColor}
 							placeholderTextColor={labelColor}
@@ -282,6 +284,7 @@ const LoginForm = ({
 							autoCorrect={false}
 						/>
 						<TouchableOpacity
+							testID="login-toggle-password"
 							className="p-1"
 							onPress={() => setShowPassword(!showPassword)}
 						>
@@ -299,6 +302,7 @@ const LoginForm = ({
 				</View>
 
 				<Button
+					testID="login-submit"
 					disabled={signInDisabled}
 					loading={loading}
 					onPress={() =>
@@ -328,6 +332,7 @@ const LoginForm = ({
 				</View>
 
 				<TouchableOpacity
+					testID="login-guest"
 					className="w-full items-center pt-1.5 mt-3.5"
 					onPress={() =>
 						guestLogin().catch((error: unknown) => console.debug(error))

--- a/src/components/Universal/multi-section-picker.tsx
+++ b/src/components/Universal/multi-section-picker.tsx
@@ -36,6 +36,12 @@ const MultiSectionPicker = ({
 				<React.Fragment key={index}>
 					<View className="h-[52px]">
 						<Pressable
+							testID={`multi-option-${item.key}`}
+							accessibilityRole="checkbox"
+							accessibilityState={{
+								checked: selectedItems.includes(item.key),
+								disabled: item.disabled
+							}}
 							onPress={() => {
 								if (!item.disabled) {
 									if (Platform.OS === 'ios') void selectionAsync()

--- a/src/components/Universal/multi-section-picker.tsx
+++ b/src/components/Universal/multi-section-picker.tsx
@@ -29,6 +29,7 @@ const MultiSectionPicker = ({
 	const labelColor = String(
 		toColor(useCSSVariable('--color-label')) ?? '#606062'
 	)
+	const selectedItemKeys = new Set(selectedItems)
 
 	return (
 		<>
@@ -39,7 +40,7 @@ const MultiSectionPicker = ({
 							testID={`multi-option-${item.key}`}
 							accessibilityRole="checkbox"
 							accessibilityState={{
-								checked: selectedItems.includes(item.key),
+								checked: selectedItemKeys.has(item.key),
 								disabled: item.disabled
 							}}
 							onPress={() => {
@@ -61,7 +62,7 @@ const MultiSectionPicker = ({
 							>
 								{item.title}
 							</Text>
-							{selectedItems.includes(item.key) && (
+							{selectedItemKeys.has(item.key) && (
 								<PlatformIcon
 									ios={{ name: 'checkmark.circle.fill', size: 18 }}
 									android={{ name: 'check_circle', size: 21 }}

--- a/src/components/Universal/row-entry.tsx
+++ b/src/components/Universal/row-entry.tsx
@@ -10,7 +10,8 @@ const RowEntry = ({
 	onPress,
 	href,
 	backgroundColor,
-	icon
+	icon,
+	testID
 }: {
 	title: string
 	leftChildren: React.JSX.Element
@@ -20,6 +21,7 @@ const RowEntry = ({
 	isExamCard?: boolean
 	backgroundColor?: string
 	icon?: React.JSX.Element
+	testID?: string
 }): React.JSX.Element => {
 	const content = (
 		<View
@@ -53,7 +55,11 @@ const RowEntry = ({
 
 	if (!href) {
 		return onPress ? (
-			<Pressable onPress={onPress} className="active:opacity-90">
+			<Pressable
+				testID={testID}
+				onPress={onPress}
+				className="active:opacity-90"
+			>
 				{content}
 			</Pressable>
 		) : (
@@ -63,7 +69,11 @@ const RowEntry = ({
 
 	return (
 		<Link href={href} asChild>
-			<Pressable onPress={onPress} className="active:opacity-90">
+			<Pressable
+				testID={testID}
+				onPress={onPress}
+				className="active:opacity-90"
+			>
 				{content}
 			</Pressable>
 		</Link>

--- a/src/components/Universal/share-header-button.tsx
+++ b/src/components/Universal/share-header-button.tsx
@@ -33,6 +33,9 @@ export function ShareHeaderButton({
 	if (noShare) return undefined
 	return (
 		<Pressable
+			testID="share-header-button"
+			accessible
+			accessibilityRole="button"
 			onPress={() => {
 				void onPress()
 				if (Platform.OS === 'web') {
@@ -68,7 +71,13 @@ export const CloseHeaderButton = (): React.JSX.Element | undefined => {
 
 	if (Platform.OS !== 'ios') return undefined
 	return (
-		<Pressable onPress={() => router.back()} style={shareButtonStyle}>
+		<Pressable
+			testID="close-header-button"
+			accessible
+			accessibilityRole="button"
+			onPress={() => router.back()}
+			style={shareButtonStyle}
+		>
 			<PlatformIcon
 				ios={{ name: 'xmark', size: 15, weight: 'semibold' }}
 				android={{ name: 'close', size: 20 }}

--- a/src/components/Universal/share-header-button.tsx
+++ b/src/components/Universal/share-header-button.tsx
@@ -1,6 +1,7 @@
 import { router } from 'expo-router'
 import type React from 'react'
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Platform, Pressable } from 'react-native'
 import { useCSSVariable } from 'uniwind'
 import { toColor } from '@/utils/uniwind-utils'
@@ -24,6 +25,7 @@ export function ShareHeaderButton({
 	onPress,
 	noShare = false
 }: ShareButtonProps): React.JSX.Element | undefined {
+	const { t } = useTranslation(['accessibility'])
 	const [copied, setCopied] = useState(false)
 	const labelColor = String(
 		toColor(useCSSVariable('--color-label')) ?? '#606062'
@@ -36,6 +38,7 @@ export function ShareHeaderButton({
 			testID="share-header-button"
 			accessible
 			accessibilityRole="button"
+			accessibilityLabel={t('button.share')}
 			onPress={() => {
 				void onPress()
 				if (Platform.OS === 'web') {
@@ -64,6 +67,7 @@ export function ShareHeaderButton({
 }
 
 export const CloseHeaderButton = (): React.JSX.Element | undefined => {
+	const { t } = useTranslation(['accessibility'])
 	const labelColor = String(
 		toColor(useCSSVariable('--color-label')) ?? '#606062'
 	)
@@ -75,6 +79,7 @@ export const CloseHeaderButton = (): React.JSX.Element | undefined => {
 			testID="close-header-button"
 			accessible
 			accessibilityRole="button"
+			accessibilityLabel={t('button.close')}
 			onPress={() => router.back()}
 			style={shareButtonStyle}
 		>

--- a/src/components/Universal/single-section-picker.ios.tsx
+++ b/src/components/Universal/single-section-picker.ios.tsx
@@ -7,6 +7,7 @@ import { useCSSVariable } from 'uniwind'
 import { toColor } from '@/utils/uniwind-utils'
 
 interface SectionPickerProps {
+	testID?: string
 	title: string
 	selectedItem: boolean
 	action: (state: boolean) => void
@@ -14,6 +15,7 @@ interface SectionPickerProps {
 }
 
 const SingleSectionPicker = ({
+	testID,
 	title,
 	selectedItem,
 	action,
@@ -47,11 +49,19 @@ const SingleSectionPicker = ({
 				>
 					{title}
 				</Text>
-				<Toggle
-					isOn={isOn}
-					onChange={handleToggleChange}
-					style={disabled ? { opacity: 0.5 } : undefined}
-				/>
+				<View
+					testID={testID}
+					accessible={true}
+					accessibilityLabel={title}
+					accessibilityRole="switch"
+					accessibilityState={{ checked: selectedItem, disabled }}
+				>
+					<Toggle
+						isOn={isOn}
+						onChange={handleToggleChange}
+						style={disabled ? { opacity: 0.5 } : undefined}
+					/>
+				</View>
 			</View>
 		</View>
 	)

--- a/src/components/Universal/single-section-picker.ios.tsx
+++ b/src/components/Universal/single-section-picker.ios.tsx
@@ -55,6 +55,9 @@ const SingleSectionPicker = ({
 					accessibilityLabel={title}
 					accessibilityRole="switch"
 					accessibilityState={{ checked: selectedItem, disabled }}
+					onAccessibilityTap={() => {
+						handleToggleChange()
+					}}
 				>
 					<Toggle
 						isOn={isOn}

--- a/src/components/Universal/single-section-picker.tsx
+++ b/src/components/Universal/single-section-picker.tsx
@@ -6,6 +6,7 @@ import { toColor } from '@/utils/uniwind-utils'
 import PlatformIcon from './icon'
 
 interface SectionPickerProps {
+	testID?: string
 	title: string
 	selectedItem: boolean
 	action: (state: boolean) => void
@@ -13,6 +14,7 @@ interface SectionPickerProps {
 }
 
 const SingleSectionPicker = ({
+	testID,
 	title,
 	selectedItem,
 	action,
@@ -28,6 +30,9 @@ const SingleSectionPicker = ({
 	return (
 		<View className="h-[52px]">
 			<Pressable
+				testID={testID}
+				accessibilityRole="checkbox"
+				accessibilityState={{ checked: selectedItem, disabled }}
 				onPress={() => {
 					if (!disabled) {
 						if (Platform.OS === 'ios') void selectionAsync()

--- a/src/components/Universal/toggle-row.tsx
+++ b/src/components/Universal/toggle-row.tsx
@@ -6,11 +6,13 @@ import { hairlineBorder } from '@/utils/uniwind-utils'
 const ToggleRow = ({
 	items,
 	selectedElement,
-	setSelectedElement
+	setSelectedElement,
+	testID
 }: {
 	items: string[]
 	selectedElement: number
 	setSelectedElement: (element: number) => void
+	testID?: string
 }): React.JSX.Element => {
 	const pressHandler = (index: number) => {
 		setSelectedElement(index)
@@ -27,6 +29,9 @@ const ToggleRow = ({
 				return (
 					<View key={item} className="flex-1">
 						<Pressable
+							testID={testID == null ? undefined : `${testID}-${index}`}
+							accessibilityRole="tab"
+							accessibilityState={{ selected: isSelected }}
 							onPress={() => {
 								pressHandler(index)
 							}}

--- a/src/localization/de/accessibility.json
+++ b/src/localization/de/accessibility.json
@@ -1,5 +1,7 @@
 {
 	"button": {
+		"share": "Teilen",
+		"close": "Schließen",
 		"foodPreferences": "Essenspräferenzen",
 		"timetableMode": "Stundenplanansicht wechseln",
 		"timetableBack": "Zu heute springen",

--- a/src/localization/en/accessibility.json
+++ b/src/localization/en/accessibility.json
@@ -1,5 +1,7 @@
 {
 	"button": {
+		"share": "Share",
+		"close": "Close",
 		"foodPreferences": "Food Preferences",
 		"timetableMode": "Switch Timetable View",
 		"timetableBack": "Jump to today",

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -4,6 +4,7 @@ import type { CommunityIcon, WebIcon } from '@/components/Universal/icon'
 import type { MaterialIcon } from './material-icons'
 
 export interface SectionGroup {
+	testID?: string
 	title?: string
 	value?: string
 	customComponent?: (textStyle: StyleProp<TextStyle>) => React.ReactNode


### PR DESCRIPTION
## 📋 Description

This PR adds stable testID selectors across the app to support Maestro end-to-end testing, covering authentication, onboarding, navigation, timetable, food, map, events, member, settings, and other key flows. Reusable components now accept and forward test IDs where needed.

  It also improves accessibility by adding appropriate roles and state information to interactive controls, including checkboxes, radios, tabs, and toggles. iOS toggle activation now works correctly with VoiceOver, while icon-only share and close buttons receive localized accessibility labels. Additionally, selected-item checks in the multi-section picker were optimized by using a Set.

<!-- Please describe the changes you’ve made and the motivation behind them. -->

## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web
- [ ] I’ve added or updated documentation (if needed)
- [ ] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

<!-- Anything else reviewers should be aware of? -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>