### PR TITLE
fix: prevent changelog argument overflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      release_body: ${{ steps.git-cliff.outputs.content }}
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -55,7 +52,7 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
-          body: ${{ steps.git-cliff.outputs.content }}
+          body_path: CHANGES.md
           prerelease: ${{ env.PRERELEASE }}
           draft: true
 


### PR DESCRIPTION
## Summary

- Load generated release notes with `body_path` instead of interpolating the full changelog into an action input.
- Remove unused changelog and release outputs that could propagate large values.

## Root Cause

The release changelog was approximately 142 KB. Passing it through `body: ${{ steps.git-cliff.outputs.content }}` exceeded the Linux process argument limit before `softprops/action-gh-release` could start.

## Verification

- `bun changelog:check` passed
- `git diff --check` passed
- `actionlint .github/workflows/release.yml` parsed the workflow; existing ShellCheck warnings remain

Fixes the failure in https://github.com/neuland-ingolstadt/neuland.app-native/actions/runs/31265557431/job/93122985396