### PR TITLE
chore: bump version to 0.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.16.0",
+	"version": "0.16.1",
 	"name": "neuland",
 	"main": "expo-router/entry",
 	"homepage": "https://github.com/neuland-ingolstadt/neuland.app-native",


### PR DESCRIPTION
## Summary
- bump the app version from 0.16.0 to 0.16.1

## Validation
- bun run changelog:check
- bun tsc --noEmit
- bun lint
- bun test