### PR TITLE
fix: constrain detail-screen header titles so long names stop overflowing

### DIFF
--- a/src/app/(screens)/events/cl/[id].tsx
+++ b/src/app/(screens)/events/cl/[id].tsx
@@ -1,10 +1,8 @@
 import { trackEvent } from '@aptabase/react-native'
-import { HeaderTitle } from '@react-navigation/elements'
 import { useQuery } from '@tanstack/react-query'
 import {
 	Redirect,
 	router,
-	Stack,
 	useFocusEffect,
 	useLocalSearchParams,
 	useNavigation
@@ -21,6 +19,7 @@ import Animated, {
 } from 'react-native-reanimated'
 import { useCSSVariable, useResolveClassNames } from 'uniwind'
 import { EventErrorView } from '@/components/Error/event-error-view'
+import { DetailStackHeader } from '@/components/Universal/detail-stack-header'
 import FormList from '@/components/Universal/form-list'
 import { linkIcon } from '@/components/Universal/icon'
 import LinkText from '@/components/Universal/link-text'
@@ -52,7 +51,6 @@ import { copyToClipboard } from '@/utils/ui-utils'
 import { toColor } from '@/utils/uniwind-utils'
 
 export default function ClEventDetail(): React.JSX.Element {
-	const textColor = toColor(useCSSVariable('--color-text'))
 	const primaryColor = toColor(useCSSVariable('--color-primary'))
 	const columnDetailsStyle = useResolveClassNames(
 		'text-text text-[16.5px] pt-0.5 text-left'
@@ -363,25 +361,7 @@ export default function ClEventDetail(): React.JSX.Element {
 			onScroll={scrollHandler}
 			scrollEventThrottle={16}
 		>
-			<Stack.Screen
-				options={{
-					headerTitle: (props) => (
-						<View
-							className="overflow-hidden"
-							style={{
-								marginBottom: Platform.OS === 'ios' ? -10 : 0,
-								paddingRight: Platform.OS === 'ios' ? 0 : 50
-							}}
-						>
-							<Animated.View style={headerStyle}>
-								<HeaderTitle {...props} tintColor={String(textColor)}>
-									{eventTitle}
-								</HeaderTitle>
-							</Animated.View>
-						</View>
-					)
-				}}
-			/>
+			<DetailStackHeader title={eventTitle} headerStyle={headerStyle} />
 
 			<View className="flex-row items-start justify-between">
 				<Text

--- a/src/app/(screens)/events/sports/[id].tsx
+++ b/src/app/(screens)/events/sports/[id].tsx
@@ -1,8 +1,6 @@
 import { trackEvent } from '@aptabase/react-native'
-import { HeaderTitle } from '@react-navigation/elements'
 import { useQuery } from '@tanstack/react-query'
 import {
-	Stack,
 	useFocusEffect,
 	useLocalSearchParams,
 	useNavigation
@@ -23,6 +21,7 @@ import type {
 	WeekdayType
 } from '@/__generated__/gql/graphql'
 import { EventErrorView } from '@/components/Error/event-error-view'
+import { DetailStackHeader } from '@/components/Universal/detail-stack-header'
 import FormList from '@/components/Universal/form-list'
 import type { LucideIcon } from '@/components/Universal/icon'
 import LoadingIndicator from '@/components/Universal/loading-indicator'
@@ -37,7 +36,6 @@ import { copyToClipboard } from '@/utils/ui-utils'
 import { toColor } from '@/utils/uniwind-utils'
 
 export default function SportsEventDetail(): React.JSX.Element {
-	const textColor = toColor(useCSSVariable('--color-text'))
 	const primaryColor = toColor(useCSSVariable('--color-primary'))
 	const warningColor = toColor(useCSSVariable('--color-warning'))
 	const successColor = toColor(useCSSVariable('--color-success'))
@@ -253,25 +251,7 @@ export default function SportsEventDetail(): React.JSX.Element {
 			onScroll={scrollHandler}
 			scrollEventThrottle={16}
 		>
-			<Stack.Screen
-				options={{
-					headerTitle: (props) => (
-						<View
-							className="overflow-hidden"
-							style={{
-								marginBottom: Platform.OS === 'ios' ? -10 : 0,
-								paddingRight: Platform.OS === 'ios' ? 0 : 50
-							}}
-						>
-							<Animated.View style={headerStyle}>
-								<HeaderTitle {...props} tintColor={String(textColor)}>
-									{title}
-								</HeaderTitle>
-							</Animated.View>
-						</View>
-					)
-				}}
-			/>
+			<DetailStackHeader title={title} headerStyle={headerStyle} />
 
 			<View className="flex-row items-start pl-1.5 pb-1.5 justify-between">
 				<Text

--- a/src/app/(screens)/exam.tsx
+++ b/src/app/(screens)/exam.tsx
@@ -1,8 +1,7 @@
-import { HeaderTitle } from '@react-navigation/elements'
-import { router, Stack } from 'expo-router'
+import { router } from 'expo-router'
 import type React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform, Pressable, Text, View } from 'react-native'
+import { Pressable, Text, View } from 'react-native'
 import Animated, {
 	interpolate,
 	useAnimatedRef,
@@ -10,6 +9,7 @@ import Animated, {
 	useScrollViewOffset
 } from 'react-native-reanimated'
 import { useCSSVariable } from 'uniwind'
+import { DetailStackHeader } from '@/components/Universal/detail-stack-header'
 import FormList from '@/components/Universal/form-list'
 import useRouteParamsStore from '@/hooks/useRouteParamsStore'
 import type { FormListSections } from '@/types/components'
@@ -19,7 +19,6 @@ import { toColor } from '@/utils/uniwind-utils'
 export default function ExamDetail(): React.JSX.Element {
 	const exam = useRouteParamsStore((state) => state.selectedExam)
 	const { t } = useTranslation('common')
-	const textColor = toColor(useCSSVariable('--color-text'))
 	const primaryColor = toColor(useCSSVariable('--color-primary'))
 	const typeSplit =
 		exam?.type !== undefined ? exam?.type.split('-').slice(-1)[0].trim() : ''
@@ -152,25 +151,7 @@ export default function ExamDetail(): React.JSX.Element {
 			contentContainerClassName="gap-3 pb-modal-bottom"
 			ref={ref}
 		>
-			<Stack.Screen
-				options={{
-					headerTitle: (props) => (
-						<View
-							className="overflow-hidden"
-							style={{
-								marginBottom: Platform.OS === 'ios' ? -10 : 0,
-								paddingRight: Platform.OS === 'ios' ? 0 : 50
-							}}
-						>
-							<Animated.View style={headerStyle}>
-								<HeaderTitle {...props} tintColor={String(textColor)}>
-									{exam?.name}
-								</HeaderTitle>
-							</Animated.View>
-						</View>
-					)
-				}}
-			/>
+			<DetailStackHeader title={exam?.name ?? ''} headerStyle={headerStyle} />
 			<View className="flex-row items-start justify-between pb-1.5">
 				<Text
 					className="text-text flex-1 text-2xl font-semibold pt-4 text-left"

--- a/src/app/(screens)/food/[id].tsx
+++ b/src/app/(screens)/food/[id].tsx
@@ -12,12 +12,10 @@ import Animated from 'react-native-reanimated'
 import { useCSSVariable } from 'uniwind'
 import { UserKindContext } from '@/components/contexts'
 import ErrorView from '@/components/Error/error-view'
-import {
-	MealDetailStackHeader,
-	useMealDetailScroll
-} from '@/components/Food/meal-detail-header'
+import { useMealDetailScroll } from '@/components/Food/meal-detail-header'
 import { createMealPreferenceAlert } from '@/components/Food/meal-preference-alert'
 import { MealPriceRow } from '@/components/Food/meal-price-row'
+import { DetailStackHeader } from '@/components/Universal/detail-stack-header'
 import FormList from '@/components/Universal/form-list'
 import PlatformIcon from '@/components/Universal/icon'
 import LoadingIndicator from '@/components/Universal/loading-indicator'
@@ -172,7 +170,7 @@ export default function FoodDetail(): React.JSX.Element {
 			onScroll={scrollHandler}
 			scrollEventThrottle={16}
 		>
-			<MealDetailStackHeader title={title} headerStyle={headerStyle} />
+			<DetailStackHeader title={title} headerStyle={headerStyle} />
 			<View className="flex-row items-start justify-between pb-1.5">
 				<Text
 					className="text-text flex-1 text-[22px] font-bold pt-4 text-left"

--- a/src/app/(screens)/lecture.tsx
+++ b/src/app/(screens)/lecture.tsx
@@ -1,9 +1,8 @@
 import { trackEvent } from '@aptabase/react-native'
-import { HeaderTitle } from '@react-navigation/elements'
-import { Stack, useFocusEffect, useNavigation, useRouter } from 'expo-router'
+import { useFocusEffect, useNavigation, useRouter } from 'expo-router'
 import React, { useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Platform, Pressable, Share, Text, View } from 'react-native'
+import { Pressable, Share, Text, View } from 'react-native'
 import Animated, {
 	interpolate,
 	useAnimatedRef,
@@ -18,6 +17,7 @@ import DetailsRow from '@/components/Timetable/details-row'
 import DetailsSymbol from '@/components/Timetable/details-symbol'
 import Separator from '@/components/Timetable/separator'
 import ShareCard from '@/components/Timetable/share-card'
+import { DetailStackHeader } from '@/components/Universal/detail-stack-header'
 import FormList from '@/components/Universal/form-list'
 import PlatformIcon from '@/components/Universal/icon'
 import useRouteParamsStore from '@/hooks/useRouteParamsStore'
@@ -172,25 +172,7 @@ export default function TimetableDetails(): React.JSX.Element {
 			ref={ref}
 			contentContainerClassName="flex pb-bottom-safe px-page pt-page"
 		>
-			<Stack.Screen
-				options={{
-					headerTitle: (props) => (
-						<View
-							className="overflow-hidden"
-							style={{
-								marginBottom: Platform.OS === 'ios' ? -10 : 0,
-								paddingRight: Platform.OS === 'ios' ? 0 : 50
-							}}
-						>
-							<Animated.View style={headerStyle}>
-								<HeaderTitle {...props} tintColor={String(textColor)}>
-									{lecture.name}
-								</HeaderTitle>
-							</Animated.View>
-						</View>
-					)
-				}}
-			/>
+			<DetailStackHeader title={lecture.name} headerStyle={headerStyle} />
 			<View>
 				<DetailsRow>
 					<DetailsSymbol>

--- a/src/app/(screens)/lecturer.tsx
+++ b/src/app/(screens)/lecturer.tsx
@@ -1,8 +1,7 @@
-import { HeaderTitle } from '@react-navigation/elements'
-import { Redirect, router, Stack } from 'expo-router'
+import { Redirect, router } from 'expo-router'
 import type React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Linking, Platform, Text, View } from 'react-native'
+import { Linking, Text, View } from 'react-native'
 import Animated, {
 	interpolate,
 	useAnimatedScrollHandler,
@@ -10,6 +9,7 @@ import Animated, {
 	useSharedValue
 } from 'react-native-reanimated'
 import { useCSSVariable } from 'uniwind'
+import { DetailStackHeader } from '@/components/Universal/detail-stack-header'
 import FormList from '@/components/Universal/form-list'
 import useRouteParamsStore from '@/hooks/useRouteParamsStore'
 import type { FormListSections } from '@/types/components'
@@ -18,7 +18,6 @@ import { toColor } from '@/utils/uniwind-utils'
 export default function LecturerDetail(): React.JSX.Element {
 	const lecturer = useRouteParamsStore((state) => state.selectedLecturer)
 	const { t } = useTranslation('common')
-	const textColor = toColor(useCSSVariable('--color-text'))
 	const primaryColor = toColor(useCSSVariable('--color-primary'))
 
 	const scrollOffset = useSharedValue(0)
@@ -149,25 +148,7 @@ export default function LecturerDetail(): React.JSX.Element {
 			onScroll={scrollHandler}
 			scrollEventThrottle={16}
 		>
-			<Stack.Screen
-				options={{
-					headerTitle: (props) => (
-						<View
-							className="overflow-hidden"
-							style={{
-								marginBottom: Platform.OS === 'ios' ? -10 : 0,
-								paddingRight: Platform.OS === 'ios' ? 0 : 50
-							}}
-						>
-							<Animated.View style={headerStyle}>
-								<HeaderTitle {...props} tintColor={String(textColor)}>
-									{lecturerName}
-								</HeaderTitle>
-							</Animated.View>
-						</View>
-					)
-				}}
-			/>
+			<DetailStackHeader title={lecturerName} headerStyle={headerStyle} />
 
 			<View className="flex-row items-start justify-between">
 				<Text

--- a/src/components/Food/meal-detail-header.tsx
+++ b/src/components/Food/meal-detail-header.tsx
@@ -1,15 +1,10 @@
-import { HeaderTitle } from '@react-navigation/elements'
-import { Stack } from 'expo-router'
 import type { ViewStyle } from 'react-native'
-import { Platform, View } from 'react-native'
-import Animated, {
+import {
 	interpolate,
 	useAnimatedScrollHandler,
 	useAnimatedStyle,
 	useSharedValue
 } from 'react-native-reanimated'
-import { useCSSVariable } from 'uniwind'
-import { toColor } from '@/utils/uniwind-utils'
 
 export function useMealDetailScroll(): {
 	scrollHandler: ReturnType<typeof useAnimatedScrollHandler>
@@ -40,38 +35,4 @@ export function useMealDetailScroll(): {
 	})
 
 	return { scrollHandler, headerStyle }
-}
-
-interface MealDetailStackHeaderProps {
-	title: string
-	headerStyle: ReturnType<typeof useAnimatedStyle<ViewStyle>>
-}
-
-export function MealDetailStackHeader({
-	title,
-	headerStyle
-}: MealDetailStackHeaderProps): React.JSX.Element {
-	const textColor = toColor(useCSSVariable('--color-text'))
-
-	return (
-		<Stack.Screen
-			options={{
-				headerTitle: (props) => (
-					<View
-						className="overflow-hidden"
-						style={{
-							marginBottom: Platform.OS === 'ios' ? -10 : 0,
-							paddingRight: Platform.OS === 'ios' ? 0 : 50
-						}}
-					>
-						<Animated.View style={headerStyle}>
-							<HeaderTitle {...props} tintColor={String(textColor)}>
-								{title}
-							</HeaderTitle>
-						</Animated.View>
-					</View>
-				)
-			}}
-		/>
-	)
 }

--- a/src/components/Universal/detail-stack-header.tsx
+++ b/src/components/Universal/detail-stack-header.tsx
@@ -1,0 +1,62 @@
+import { HeaderTitle } from '@react-navigation/elements'
+import { Stack } from 'expo-router'
+import type { ViewStyle } from 'react-native'
+import { Platform, useWindowDimensions, View } from 'react-native'
+import Animated, { type useAnimatedStyle } from 'react-native-reanimated'
+import { useCSSVariable } from 'uniwind'
+import { toColor } from '@/utils/uniwind-utils'
+
+// getPlatformHeaderButtons (@/utils/header-buttons) never renders more than
+// one button per side, so a fixed reserve is enough for every screen using
+// this header — no per-screen tuning needed.
+const HEADER_SIDE_BUTTON_WIDTH = 60
+
+interface DetailStackHeaderProps {
+	title: string
+	headerStyle: ReturnType<typeof useAnimatedStyle<ViewStyle>>
+}
+
+/**
+ * Scroll-linked detail-screen header title: translates up from below the bar
+ * into the centred position as the user scrolls, blending with the
+ * in-content title below it. Shared by every detail screen using this
+ * animation (food, exam, lecture, lecturer, sports/CL events) so a long
+ * title is constrained and truncated once here instead of in six
+ * near-identical copies — a fully custom `headerTitle` gets no native
+ * truncation against the header's side buttons.
+ */
+export function DetailStackHeader({
+	title,
+	headerStyle
+}: DetailStackHeaderProps): React.JSX.Element {
+	const textColor = toColor(useCSSVariable('--color-text'))
+	const { width } = useWindowDimensions()
+
+	return (
+		<Stack.Screen
+			options={{
+				headerTitle: (props) => (
+					<View
+						className="overflow-hidden"
+						style={{
+							marginBottom: Platform.OS === 'ios' ? -10 : 0,
+							paddingRight: Platform.OS === 'ios' ? 0 : 50,
+							maxWidth: width - HEADER_SIDE_BUTTON_WIDTH * 2
+						}}
+					>
+						<Animated.View style={headerStyle}>
+							<HeaderTitle
+								{...props}
+								tintColor={String(textColor)}
+								numberOfLines={1}
+								ellipsizeMode="tail"
+							>
+								{title}
+							</HeaderTitle>
+						</Animated.View>
+					</View>
+				)
+			}}
+		/>
+	)
+}


### PR DESCRIPTION
Closes #632.

## Root cause
The scroll-linked header title on the six affected screens (food, exam, lecture, lecturer, sports event, campus-life event detail) renders through a fully custom `headerTitle` render prop. Verified against `@react-navigation/elements`'s `HeaderTitle` source: it already defaults `numberOfLines={1}` internally, so the missing piece wasn't that prop — it's that nothing ever constrained the width of the wrapping `View`/`Animated.View`, so RN has no box to wrap/ellipsize text against and the title just paints past the header's buttons instead of truncating.

`getPlatformHeaderButtons` (`src/utils/header-buttons.tsx`) confirms the header never renders more than one button per side (share on one side, close on the other on iOS; share only on Android/web), which is what makes a single fixed reserved width safe across every screen and platform.

## What changed
- New `src/components/Universal/detail-stack-header.tsx` — one shared `DetailStackHeader` component replacing six near-identical `Stack.Screen`/`headerTitle` blocks (previously duplicated verbatim in `meal-detail-header.tsx`, `exam.tsx`, `lecture.tsx`, `lecturer.tsx`, `events/sports/[id].tsx`, `events/cl/[id].tsx`). It adds an explicit `maxWidth` (window width minus a fixed reserve for the side buttons) plus `ellipsizeMode="tail"` alongside the existing `numberOfLines` default.
- All six screens now render `<DetailStackHeader title={...} headerStyle={headerStyle} />` instead of the inline block; each screen still owns its own scroll-driven `headerStyle` animation (untouched) and just hands it to the shared component.
- `meal-detail-header.tsx` keeps only `useMealDetailScroll` — its render half moved to the new shared component.
- Removed now-unused imports/variables (`HeaderTitle`, `Stack`, `Platform`, per-screen `textColor`) from the five screens that no longer need them directly.

Net diff removes more lines than it adds (-157/+82) despite fixing the bug, since the six duplicated blocks collapse into one.

## Caveat
I don't have a simulator in my environment to visually confirm the exact pixel fit — the `HEADER_SIDE_BUTTON_WIDTH` reserve (60pt/side) is a deliberately generous, safe estimate based on the actual button sizing in `share-header-button.tsx`, not a measured value. Happy to adjust it if it's too conservative (or not conservative enough) once someone can eyeball it on-device.

## Test plan
- [x] `bun lint` (Biome) — clean
- [x] `bun tsc --noEmit` — clean
- [x] `bun i18n:check` — clean (no strings touched)
- [x] `bun test` — 273 passed (no regressions; this repo only unit-tests pure utilities per AGENTS.md, so no new tests were added for this UI-only change)