### PR TITLE
fix: resolve TypeScript errors for native tabs and color scheme

### DIFF
--- a/src/components/Layout/tab-bar.android.tsx
+++ b/src/components/Layout/tab-bar.android.tsx
@@ -5,21 +5,11 @@ import { useColorScheme } from 'react-native'
 import { useBottomTabBarHeight as _useBottomTabBarHeight } from 'react-native-bottom-tabs'
 import { useCSSVariable } from 'uniwind'
 import { usePreferencesStore } from '@/hooks/usePreferencesStore'
+import { resolveActiveTheme } from '@/utils/theme-utils'
 import { toColor } from '@/utils/uniwind-utils'
 import { Tabs } from './native-bottom-tabs'
 
 export const useBottomTabBarHeight = _useBottomTabBarHeight
-
-function resolveActiveTheme(
-	theme: string,
-	colorScheme: 'light' | 'dark' | null | undefined
-): 'light' | 'dark' {
-	if (theme === 'light' || theme === 'dark') {
-		return theme
-	}
-
-	return colorScheme === 'dark' ? 'dark' : 'light'
-}
 
 export default function TabLayout(): React.JSX.Element {
 	const themePreference = usePreferencesStore((state) => state.theme)

--- a/src/components/Layout/tab-bar.tsx
+++ b/src/components/Layout/tab-bar.tsx
@@ -1,23 +1,12 @@
 import Color from 'color'
-import { Icon, Label } from 'expo-router/build/native-tabs/common/elements'
 import { NativeTabs } from 'expo-router/unstable-native-tabs'
 import type React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Platform, useColorScheme } from 'react-native'
 import { useCSSVariable } from 'uniwind'
 import { usePreferencesStore } from '@/hooks/usePreferencesStore'
+import { resolveActiveTheme } from '@/utils/theme-utils'
 import { toColor } from '@/utils/uniwind-utils'
-
-function resolveActiveTheme(
-	theme: string,
-	colorScheme: 'light' | 'dark' | null | undefined
-): 'light' | 'dark' {
-	if (theme === 'light' || theme === 'dark') {
-		return theme
-	}
-
-	return colorScheme === 'dark' ? 'dark' : 'light'
-}
 
 export default function TabLayout(): React.JSX.Element {
 	const themePreference = usePreferencesStore((state) => state.theme)
@@ -60,14 +49,16 @@ export default function TabLayout(): React.JSX.Element {
 			disableTransparentOnScrollEdge={!isIos26}
 		>
 			<NativeTabs.Trigger name="index">
-				<Label>{t('navigation.home')}</Label>
+				<NativeTabs.Trigger.Label>
+					{t('navigation.home')}
+				</NativeTabs.Trigger.Label>
 				{Platform.OS === 'ios' ? (
-					<Icon
+					<NativeTabs.Trigger.Icon
 						sf={{ default: 'house', selected: 'house.fill' }}
 						selectedColor={primaryColor}
 					/>
 				) : (
-					<Icon
+					<NativeTabs.Trigger.Icon
 						src={{
 							default: require('../../assets/tabbar/home.svg'),
 							selected: require('../../assets/tabbar/home_fill.svg')
@@ -76,14 +67,16 @@ export default function TabLayout(): React.JSX.Element {
 				)}
 			</NativeTabs.Trigger>
 			<NativeTabs.Trigger name="timetable">
-				<Label>{t('navigation.timetable')}</Label>
+				<NativeTabs.Trigger.Label>
+					{t('navigation.timetable')}
+				</NativeTabs.Trigger.Label>
 				{Platform.OS === 'ios' ? (
-					<Icon
+					<NativeTabs.Trigger.Icon
 						sf={{ default: 'clock', selected: 'clock.fill' }}
 						selectedColor={primaryColor}
 					/>
 				) : (
-					<Icon
+					<NativeTabs.Trigger.Icon
 						src={{
 							default: require('../../assets/tabbar/calendar_month.svg'),
 							selected: require('../../assets/tabbar/calendar_month_fill.svg')
@@ -92,14 +85,16 @@ export default function TabLayout(): React.JSX.Element {
 				)}
 			</NativeTabs.Trigger>
 			<NativeTabs.Trigger name="map">
-				<Label>{t('navigation.map')}</Label>
+				<NativeTabs.Trigger.Label>
+					{t('navigation.map')}
+				</NativeTabs.Trigger.Label>
 				{Platform.OS === 'ios' ? (
-					<Icon
+					<NativeTabs.Trigger.Icon
 						sf={{ default: 'map', selected: 'map.fill' }}
 						selectedColor={primaryColor}
 					/>
 				) : (
-					<Icon
+					<NativeTabs.Trigger.Icon
 						src={{
 							default: require('../../assets/tabbar/map.svg'),
 							selected: require('../../assets/tabbar/map_fill.svg')
@@ -108,14 +103,16 @@ export default function TabLayout(): React.JSX.Element {
 				)}
 			</NativeTabs.Trigger>
 			<NativeTabs.Trigger name="food">
-				<Label>{t('navigation.food')}</Label>
+				<NativeTabs.Trigger.Label>
+					{t('navigation.food')}
+				</NativeTabs.Trigger.Label>
 				{Platform.OS === 'ios' ? (
-					<Icon
+					<NativeTabs.Trigger.Icon
 						sf={{ default: 'fork.knife', selected: 'fork.knife' }}
 						selectedColor={primaryColor}
 					/>
 				) : (
-					<Icon
+					<NativeTabs.Trigger.Icon
 						src={{
 							default: require('../../assets/tabbar/food.svg'),
 							selected: require('../../assets/tabbar/food_fill.svg')
@@ -124,14 +121,16 @@ export default function TabLayout(): React.JSX.Element {
 				)}
 			</NativeTabs.Trigger>
 			<NativeTabs.Trigger name="settings">
-				<Label>{t('navigation.profile')}</Label>
+				<NativeTabs.Trigger.Label>
+					{t('navigation.profile')}
+				</NativeTabs.Trigger.Label>
 				{Platform.OS === 'ios' ? (
-					<Icon
+					<NativeTabs.Trigger.Icon
 						sf={{ default: 'person', selected: 'person.fill' }}
 						selectedColor={primaryColor}
 					/>
 				) : (
-					<Icon
+					<NativeTabs.Trigger.Icon
 						src={{
 							default: require('../../assets/tabbar/account_circle.svg'),
 							selected: require('../../assets/tabbar/account_circle_fill.svg')

--- a/src/components/Universal/button.tsx
+++ b/src/components/Universal/button.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native'
 import { useCSSVariable } from 'uniwind'
 import { usePreferencesStore } from '@/hooks/usePreferencesStore'
+import { resolveActiveTheme } from '@/utils/theme-utils'
 import { getContrastColor } from '@/utils/ui-utils'
 import { hairlineBorder, toColor } from '@/utils/uniwind-utils'
 
@@ -21,17 +22,6 @@ interface ButtonProps {
 	onPress: () => void
 	children: string
 	style?: StyleProp<ViewStyle>
-}
-
-function resolveActiveTheme(
-	theme: string,
-	colorScheme: 'light' | 'dark' | null | undefined
-): 'light' | 'dark' {
-	if (theme === 'light' || theme === 'dark') {
-		return theme
-	}
-
-	return colorScheme === 'dark' ? 'dark' : 'light'
 }
 
 const Button = ({

--- a/src/components/provider.tsx
+++ b/src/components/provider.tsx
@@ -120,7 +120,7 @@ function ProviderContent({ children }: ProviderProps): React.JSX.Element {
 
 		const isFixedTheme = theme === 'dark' || theme === 'light'
 		if (Platform.OS !== 'web') {
-			Appearance.setColorScheme(isFixedTheme ? theme : undefined)
+			Appearance.setColorScheme(isFixedTheme ? theme : 'unspecified')
 		}
 
 		return () => {

--- a/src/components/splash.tsx
+++ b/src/components/splash.tsx
@@ -19,6 +19,7 @@ import Animated, {
 import Svg, { G, Path } from 'react-native-svg'
 import { useCSSVariable } from 'uniwind'
 import { usePreferencesStore } from '@/hooks/usePreferencesStore'
+import { resolveActiveTheme } from '@/utils/theme-utils'
 import { toColor } from '@/utils/uniwind-utils'
 
 const AnimatedSvg = Animated.createAnimatedComponent(Svg)
@@ -52,17 +53,6 @@ const Logo = ({ style, width, height, color, opacity }: LogoProps) => (
 )
 
 type Props = { isReady: boolean }
-
-function resolveActiveTheme(
-	theme: string,
-	colorScheme: 'light' | 'dark' | null | undefined
-): 'light' | 'dark' {
-	if (theme === 'light' || theme === 'dark') {
-		return theme
-	}
-
-	return colorScheme === 'dark' ? 'dark' : 'light'
-}
 
 export function Splash({ isReady, children }: React.PropsWithChildren<Props>) {
 	const themePreference = usePreferencesStore((state) => state.theme)

--- a/src/utils/theme-utils.ts
+++ b/src/utils/theme-utils.ts
@@ -1,0 +1,12 @@
+import type { ColorSchemeName } from 'react-native'
+
+export function resolveActiveTheme(
+	theme: string,
+	colorScheme: ColorSchemeName
+): 'light' | 'dark' {
+	if (theme === 'light' || theme === 'dark') {
+		return theme
+	}
+
+	return colorScheme === 'dark' ? 'dark' : 'light'
+}


### PR DESCRIPTION
## 📋 Description

Fixes CI TypeScript failures introduced by updated React Native and expo-router types.

- Migrate iOS tab bar from the removed internal `Icon`/`Label` imports to the public `NativeTabs.Trigger.Icon` and `NativeTabs.Trigger.Label` API
- Extract shared `resolveActiveTheme` helper that accepts React Native's `ColorSchemeName` (including `'unspecified'`)
- Use `'unspecified'` instead of `undefined` when resetting `Appearance.setColorScheme` for system theme preference

## ✅ Checklist

- [ ] I’ve tested my changes on iOS
- [ ] I’ve tested my changes on Android
- [ ] I’ve tested my changes on Web
- [ ] I’ve added or updated documentation (if needed)
- [ ] I’ve reviewed the related issues, if any

## 🗒️ Additional Notes

Verified locally with `bun tsc --noEmit`, `bun lint`, and `bun test --ci` (306 pass).