### PR TITLE
ci: add Maestro web E2E check on pull requests

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -11,6 +11,7 @@ web:
   - 'package.json'
   - 'bun.lock'
   - 'patches/**'
+  - '.maestro/**'
 
 android:
   - 'app.config.ts'

--- a/.github/workflows/maestro-web.yml
+++ b/.github/workflows/maestro-web.yml
@@ -1,0 +1,99 @@
+name: Maestro web E2E
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  merge_group:
+    types: [checks_requested]
+
+concurrency:
+  group: maestro-web-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect web-related changes
+    runs-on: ubuntu-latest
+    outputs:
+      web: ${{ steps.detect.outputs.web }}
+      workflows: ${{ steps.detect.outputs.workflows }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Detect changes
+        uses: ./.github/actions/detect-changes
+        id: detect
+
+  maestro-web:
+    name: Maestro web regression
+    needs: changes
+    if: |
+      needs.changes.outputs.web == 'true' ||
+      needs.changes.outputs.workflows == 'true' ||
+      (github.event_name == 'pull_request' &&
+        contains(toJSON(github.event.pull_request.labels.*.name), '"e2e"'))
+    # macos avoids Chromium sandbox / user-namespace issues on ubuntu-latest
+    # (https://github.com/mobile-dev-inc/maestro/issues/2576). Still free for
+    # this public repository on standard GitHub-hosted runners.
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/setup
+
+      - name: Set up Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Install Maestro CLI
+        run: |
+          curl -fsSL --retry 3 --retry-all-errors 'https://get.maestro.mobile.dev' | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+          maestro --version
+
+      - name: Export web bundle
+        env:
+          EXPO_PUBLIC_THI_API_KEY: ${{ secrets.EXPO_PUBLIC_THI_API_KEY }}
+          EXPO_PUBLIC_NEULAND_AUTHENTIK_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_NEULAND_AUTHENTIK_CLIENT_ID }}
+          EXPO_PUBLIC_NEULAND_GRAPHQL_ENDPOINT: ${{ vars.GRAPHQL_ENDPOINT_DEV }}
+          EXPO_PUBLIC_APTABASE_KEY: ${{ secrets.EXPO_PUBLIC_APTABASE_KEY }}
+          EXPO_PUBLIC_GIT_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          source config/ci/web-export-env.sh
+          bun run licences:bundle
+          bun maplibre:worker
+          npx expo export -p web -c
+
+      - name: Start static web server
+        run: |
+          bunx --bun serve dist -s -l 8081 > /tmp/maestro-web-server.log 2>&1 &
+          for _ in $(seq 1 60); do
+            if curl -fsS 'http://127.0.0.1:8081/' >/dev/null; then
+              echo 'Web server is ready'
+              exit 0
+            fi
+            sleep 2
+          done
+          echo 'Web server failed to become ready' >&2
+          cat /tmp/maestro-web-server.log >&2 || true
+          exit 1
+
+      - name: Run Maestro web E2E
+        run: bun e2e:web
+
+      - name: Upload Maestro artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: maestro-web-${{ github.run_id }}
+          path: |
+            ~/.maestro/tests
+            /tmp/maestro-web-server.log
+          if-no-files-found: ignore
+          retention-days: 14
+          include-hidden-files: true

--- a/.github/workflows/maestro-web.yml
+++ b/.github/workflows/maestro-web.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           curl -fsSL --retry 3 --retry-all-errors 'https://get.maestro.mobile.dev' | bash
           echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.maestro/bin:$PATH"
           maestro --version
 
       - name: Export web bundle

--- a/.maestro/flows/web-regression.yaml
+++ b/.maestro/flows/web-regression.yaml
@@ -66,14 +66,13 @@ tags:
     start: "70%, 35%"
     end: "30%, 35%"
     duration: 700
-- tapOn:
-    id: "map-floor-picker"
+# On web, Maestro exposes accessibilityLabel as resource-id (not testID) for
+# the floor picker Pressables — "Floor picker" / floor labels like "0", "-1".
+- tapOn: "(Floor picker|Etagenauswahl)"
 - extendedWaitUntil:
-    visible:
-      id: "map-floor-EG"
+    visible: "-1"
     timeout: 10000
-- tapOn:
-    id: "map-floor-EG"
+- tapOn: "-1"
 - tapOn:
     id: "map-search-input"
 - inputText: "B106"

--- a/.maestro/flows/web-regression.yaml
+++ b/.maestro/flows/web-regression.yaml
@@ -104,7 +104,8 @@ tags:
           id: "food-day-1"
       - assertVisible:
           id: "food-day-1"
-- tapOn: "(Food Preferences|Essenspräferenzen)"
+- tapOn:
+    id: "(Food Preferences|Essenspräferenzen)"
 - extendedWaitUntil:
     visible:
       id: "multi-option-Reimanns"

--- a/.maestro/flows/web-regression.yaml
+++ b/.maestro/flows/web-regression.yaml
@@ -85,8 +85,9 @@ tags:
     id: "map-search-result-B106"
 - assertVisible:
     id: "map-room-detail"
-- tapOn:
-    id: "map-room-detail-close"
+- assertVisible: "B106"
+# Room detail Close exposes accessibilityLabel ("Close"), which collides with
+# the floor-picker Close control — just leave via navigation.
 - openLink: "${WEB_URL}/food"
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/web-regression.yaml
+++ b/.maestro/flows/web-regression.yaml
@@ -33,12 +33,15 @@ tags:
     visible:
       id: "login-guest"
     timeout: 120000
+# Do not center: Maestro web treats the already-visible guest link as gone
+# after a centering scroll (100% visibility + centerElement).
 - scrollUntilVisible:
     element:
       id: "login-guest"
     direction: DOWN
     timeout: 15000
-    centerElement: true
+    visibilityPercentage: 40
+    centerElement: false
 - tapOn:
     id: "login-guest"
 - extendedWaitUntil:

--- a/.maestro/flows/web-regression.yaml
+++ b/.maestro/flows/web-regression.yaml
@@ -66,13 +66,15 @@ tags:
     start: "70%, 35%"
     end: "30%, 35%"
     duration: 700
-# On web, Maestro exposes accessibilityLabel as resource-id (not testID) for
-# the floor picker Pressables — "Floor picker" / floor labels like "0", "-1".
-- tapOn: "(Floor picker|Etagenauswahl)"
+# On web, Maestro maps accessibilityLabel → resource-id (not visible text).
+- tapOn:
+    id: "(Floor picker|Etagenauswahl)"
 - extendedWaitUntil:
-    visible: "-1"
+    visible:
+      id: "-1"
     timeout: 10000
-- tapOn: "-1"
+- tapOn:
+    id: "-1"
 - tapOn:
     id: "map-search-input"
 - inputText: "B106"

--- a/.maestro/flows/web-regression.yaml
+++ b/.maestro/flows/web-regression.yaml
@@ -48,6 +48,21 @@ tags:
     visible:
       id: "home-screen"
     timeout: 20000
+
+# Sidebar / tab navigation (guest)
+- tapOn: "(Calendar|Kalender)"
+- extendedWaitUntil:
+    visible:
+      id: "timetable-screen"
+    timeout: 15000
+- assertVisible: ".*(Sign in|Anmelden).*"
+- tapOn: "(Home|Startseite)"
+- extendedWaitUntil:
+    visible:
+      id: "home-screen"
+    timeout: 10000
+
+# Map
 - openLink: "${WEB_URL}/map"
 - extendedWaitUntil:
     visible:
@@ -66,7 +81,7 @@ tags:
     start: "70%, 35%"
     end: "30%, 35%"
     duration: 700
-# On web, Maestro maps accessibilityLabel → resource-id (not visible text).
+# On web, Maestro maps accessibilityLabel → resource-id (not visible text / testID).
 - tapOn:
     id: "(Floor picker|Etagenauswahl)"
 - extendedWaitUntil:
@@ -86,8 +101,8 @@ tags:
 - assertVisible:
     id: "map-room-detail"
 - assertVisible: "B106"
-# Room detail Close exposes accessibilityLabel ("Close"), which collides with
-# the floor-picker Close control — just leave via navigation.
+
+# Food menu + meal detail
 - openLink: "${WEB_URL}/food"
 - extendedWaitUntil:
     visible:
@@ -104,12 +119,35 @@ tags:
           id: "food-day-1"
       - assertVisible:
           id: "food-day-1"
+- scrollUntilVisible:
+    element:
+      id: "food-meal-entry"
+    direction: DOWN
+    timeout: 15000
+    visibilityPercentage: 40
+    centerElement: false
+- tapOn:
+    id: "food-meal-entry"
+    index: 0
+# Animated.ScrollView testID is not exposed in Maestro's web tree.
+- extendedWaitUntil:
+    visible: ".*(Student|Guest|Gast|Employee|Mitarbeiter).*"
+    timeout: 15000
+- assertVisible:
+    id: "(Home, back|Startseite, zurück)"
+- openLink: "${WEB_URL}/food"
+- extendedWaitUntil:
+    visible:
+      id: "food-screen"
+    timeout: 15000
 - tapOn:
     id: "(Food Preferences|Essenspräferenzen)"
 - extendedWaitUntil:
     visible:
       id: "multi-option-Reimanns"
     timeout: 10000
+
+# Settings + theme persistence (reload via openLink)
 - openLink: "${WEB_URL}/settings"
 - extendedWaitUntil:
     visible:
@@ -117,5 +155,23 @@ tags:
     timeout: 10000
 - assertVisible:
     id: "guest-login-banner"
+# FormList rows expose title as resource-id on web, not settings-theme-link.
+- openLink: "${WEB_URL}/theme"
+- extendedWaitUntil:
+    visible:
+      id: "theme-screen"
+    timeout: 10000
+- tapOn: "(Dark|Dunkel)"
+- assertVisible: "(Dark|Dunkel)"
+- openLink: "${WEB_URL}/theme"
+- extendedWaitUntil:
+    visible:
+      id: "theme-screen"
+    timeout: 10000
+- assertVisible: "(Dark|Dunkel)"
+- tapOn: "(Automatic|Automatisch)"
+- assertVisible: "(Automatic|Automatisch)"
+
+# 404
 - openLink: "${WEB_URL}/this-route-must-not-exist"
 - assertVisible: ".*(Not found|Nicht gefunden).*"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that exports the web app, serves the static `dist` bundle, and runs `bun e2e:web` (Maestro headless) on PRs / merge queue.
- Triggers on web-related path changes (including `.maestro/**`), workflow changes, or the `e2e` label.
- Uses `macos-latest` to avoid Ubuntu Chromium sandbox issues; standard runners remain free on this public repo.

## Test plan
- [ ] Open/update a PR that touches `src/` or `.maestro/` and confirm the `Maestro web E2E` workflow runs
- [ ] Verify the job exports the web bundle, serves `:8081`, and passes `web-regression`
- [ ] On failure, confirm Maestro artifacts (`~/.maestro/tests`) are uploaded
- [ ] Label an unrelated PR with `e2e` and confirm the workflow can be forced